### PR TITLE
make nushell script cross platform

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -168,9 +168,9 @@ end
 
 ```shell
 def-env ya [] {
-	let tmp = (mktemp -t "yazi-cwd.XXXXX")
+	let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
 	yazi --cwd-file $tmp
-	let cwd = (cat -- $tmp)
+	let cwd = (open $tmp)
 	if $cwd != "" and $cwd != $env.PWD {
 		cd $cwd
 	}


### PR DESCRIPTION
`mktemp` and `cat` don't exist on windows, so we use the builtin nushell commands