### PR TITLE
docs: fix Nushell shell script

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -53,7 +53,7 @@ end
 
 ```sh
 def --env ya [args?] {
-	let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
+	let tmp = (mktemp -t "yazi-cwd.XXXXX")
 	yazi $args --cwd-file $tmp
 	let cwd = (open $tmp)
 	if $cwd != "" and $cwd != $env.PWD {


### PR DESCRIPTION
Use the Nushell mktemp command to avoid [errors](https://github.com/sxyazi/yazi/discussions/501) when attempting to read the TEMP variable.

Improve #18 