### PR TITLE
Use nushell arguments spreading

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -52,14 +52,14 @@ end
   <TabItem value="nushell" label="Nushell">
 
 ```sh
-def --env ya [args?] {
+def --env ya [...args: string] {
 	let tmp = (mktemp -t "yazi-cwd.XXXXX")
-	yazi $args --cwd-file $tmp
+	yazi ...$args --cwd-file $tmp
 	let cwd = (open $tmp)
 	if $cwd != "" and $cwd != $env.PWD {
 		cd $cwd
 	}
-	rm -f $tmp
+	rm -fp $tmp
 }
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -52,7 +52,7 @@ end
   <TabItem value="nushell" label="Nushell">
 
 ```sh
-def --env ya [...args: string] {
+def --env ya [...args] {
 	let tmp = (mktemp -t "yazi-cwd.XXXXX")
 	yazi ...$args --cwd-file $tmp
 	let cwd = (open $tmp)


### PR DESCRIPTION
In the newest release of nushell, the current `ya` command forces the user to add an argument, or else they'll get the error `Cannot convert nothing to a string`. This simple pull request allows for no arguments by using arguments spreading.

On top of that, I've added the `-p` flag to the `rm` command which forces permanent deleting. `rm` is bundled with nushell and is cross platform, so this should work on all platforms.

Improve #27 