### PR TITLE
docs: fix nix home-manager url

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,7 +75,7 @@ environment.systemPackages = with pkgs; [
 ];
 ```
 
-You can also manage Yazi's configuration using [home-manager](https://nix-community.github.io/home-manager/options.html#opt-programs.yazi.enable).
+You can also manage Yazi's configuration using [home-manager](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.yazi.enable).
 
 ## MacPorts
 


### PR DESCRIPTION
I noticed the URL used for nix home-manager options was not valid, turns out it's just a one character fix!