### PR TITLE
docs: update Windows installation instruction to use `YAZI_FILE_ONE` for `file(1)` path

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,7 +103,7 @@ Yazi relies on `file(1)` to detect the `mime-type` of the file, and the easiest 
    - If you installed Git with Scoop, it would be `C:\Users\USERNAME\scoop\apps\git\current`.
 3. Restart your terminal.
 
-This is **the ONLY way we recommend**. We do not recommend install it via Scoop or Chocolatey, since they cannot handle Unicode filenames (such as `oliver-sjöström.jpg`) properly and lack some required parameters.
+This is **the ONLY way we recommend**. We do not recommend install `file` via Scoop or Chocolatey, since they cannot handle Unicode filenames (such as `oliver-sjöström.jpg`) properly and lack some required parameters.
 
 ### Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,7 +98,7 @@ Windows has been supported since Yazi v0.1.4, but it's still in the early stage,
 Yazi relies on `file(1)` to detect the mime-type of the file, and the easiest and most reliable way to get it on Windows is to install Git for Windows and use the `file(1)` that comes with it.
 
 1. Install Git for Windows by running [the official installer](https://git-scm.com/download/win), or through your package manager of choice.
-2. To allow Yazi to find `file(1)`, add `<Git_Installed_Directory>\usr\bin\` to your `%YAZI_FILE_ONE%` environment variable, which differs depending on how you installed Git:
+2. To allow Yazi to find `file(1)`, add `<Git_Installed_Directory>\usr\bin\` to your `YAZI_FILE_ONE` environment variable, which differs depending on how you installed Git:
    - If you installed Git with the installer, it would be `C:\Program Files\Git\usr\bin`.
    - If you installed Git with Scoop, it would be `C:\Users\<Username>\scoop\apps\git\current\usr\bin`.
 3. Restart your terminal.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,12 +95,12 @@ Windows has been supported since Yazi v0.1.4, but it's still in the early stage,
 
 ### Requirements
 
-Yazi relies on `file(1)` to detect the `mime-type` of the file, and the easiest and most reliable way to get it on Windows is to install Git for Windows and use the `file(1)` that comes with it.
+Yazi relies on `file(1)` to detect the mime-type of the file, and the easiest and most reliable way to get it on Windows is to install Git for Windows and use the `file(1)` that comes with it.
 
 1. Install Git for Windows by running [the official installer](https://git-scm.com/download/win), or through your package manager of choice.
-2. To allow Yazi to find `file(1)`, you can either set `YAZI_FILE_ONE` environment variable to `<Git_Installed_Directory>\usr\bin\file.exe` (recommended) or add `<Git_Installed_Directory>\usr\bin\` to your `%PATH%` environment variable. The `<Git_Installed_Directory>` part differs depending on how you installed Git:
-   - If you installed Git with the installer, it would be `C:\Program Files\Git`.
-   - If you installed Git with Scoop, it would be `C:\Users\USERNAME\scoop\apps\git\current`.
+2. To allow Yazi to find `file(1)`, add `<Git_Installed_Directory>\usr\bin\` to your `%YAZI_FILE_ONE%` environment variable, which differs depending on how you installed Git:
+   - If you installed Git with the installer, it would be `C:\Program Files\Git\usr\bin`.
+   - If you installed Git with Scoop, it would be `C:\Users\<Username>\scoop\apps\git\current\usr\bin`.
 3. Restart your terminal.
 
 This is **the ONLY way we recommend**. We do not recommend install `file` via Scoop or Chocolatey, since they cannot handle Unicode filenames (such as `oliver-sjöström.jpg`) properly and lack some required parameters.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,17 +98,10 @@ Windows has been supported since Yazi v0.1.4, but it's still in the early stage,
 Yazi relies on `file(1)` to detect the `mime-type` of the file, and the easiest and most reliable way to get it on Windows is to install Git for Windows and use the `file(1)` that comes with it.
 
 1. Install Git for Windows by running [the official installer](https://git-scm.com/download/win), or through your package manager of choice.
-2. To allow Yazi to find `file(1)`, add `C:\Git_Installed_Directory\usr\bin\` to your `%PATH%` environment variable, which differs depending on how you installed Git:
-   - If you installed Git with the installer, it would be `C:\Program Files\Git\usr\bin`.
-   - If you installed Git with Scoop, it would be `C:\Users\USERNAME\scoop\apps\git\current\usr\bin`.
+2. To allow Yazi to find `file(1)`, you can either set `YAZI_FILE_ONE` environment variable to `<Git_Installed_Directory>\usr\bin\file.exe` (recommended) or add `<Git_Installed_Directory>\usr\bin\` to your `%PATH%` environment variable. The `<Git_Installed_Directory>` part differs depending on how you installed Git:
+   - If you installed Git with the installer, it would be `C:\Program Files\Git`.
+   - If you installed Git with Scoop, it would be `C:\Users\USERNAME\scoop\apps\git\current`.
 3. Restart your terminal.
-
-To check if you've done this properly, enter `file -v`, you should see output similar to the following:
-
-```powershell
-C:\Users\yazi> file -v
-file-5.45
-```
 
 This is **the ONLY way we recommend**. We do not recommend install it via Scoop or Chocolatey, since they cannot handle Unicode filenames (such as `oliver-sjöström.jpg`) properly and lack some required parameters.
 


### PR DESCRIPTION
Update documentation for https://github.com/sxyazi/yazi/pull/752