### PR TITLE
docs: improve example

### DIFF
--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -361,7 +361,7 @@ Returns `(cha, err)`:
 You can invoke external programs through:
 
 ```lua
-local child = Command("ls")
+local child, err = Command("ls")
 	:args({ "-a", "-l" })
 	:stdout(Command.PIPED)
 	:spawn()


### PR DESCRIPTION
Spawn the command returns `(child, err)`