### PR TITLE
Small fix to docs on DDS

### DIFF
--- a/docs/dds.md
+++ b/docs/dds.md
@@ -379,7 +379,7 @@ This is useful for synchronizing the CWD of the current Yazi instance when exiti
 
 ```sh
 # Change Yazi's CWD to PWD on subshell exit
-if [[ -n YAZI_ID ]]; then
+if [[ ! -z "$YAZI_ID" ]]; then
 	function _yazi_cd() {
 		ya pub "$YAZI_ID" dds-cd --str "$PWD"
 	}

--- a/docs/dds.md
+++ b/docs/dds.md
@@ -379,7 +379,7 @@ This is useful for synchronizing the CWD of the current Yazi instance when exiti
 
 ```sh
 # Change Yazi's CWD to PWD on subshell exit
-if [[ ! -z "$YAZI_ID" ]]; then
+if [[ -n "$YAZI_ID" ]]; then
 	function _yazi_cd() {
 		ya pub "$YAZI_ID" dds-cd --str "$PWD"
 	}


### PR DESCRIPTION
The current if condition does not correctly check if the env variable exists and thus triggers the function in every zsh exit (even if it is not a subshell from yazi).