### PR TITLE
docs: fix Helix file picker shell code

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -454,7 +454,7 @@ Then save the following script as `~/.config/helix/yazi-picker.sh`:
 ```sh
 #!/usr/bin/env bash
 
-paths=$(yazi --chooser-file=/dev/stdout | xargs -I {} command printf "%q " {})
+paths=$(yazi --chooser-file=/dev/stdout | xargs -I {} printf "%q " {})
 
 if [[ -n "$paths" ]]; then
 	zellij action toggle-floating-panes


### PR DESCRIPTION
`xargs` can't execute anything but commands (binaries), and `command` probably isn't a binary on anyone's system, so we want to skip using it