### PR TITLE
docs: fix Helix file picker shell code

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -454,9 +454,7 @@ Then save the following script as `~/.config/helix/yazi-picker.sh`:
 ```sh
 #!/usr/bin/env bash
 
-paths="$(yazi --chooser-file=/dev/stdout | while read -r; do
-  command printf '%q ' "$REPLY"
-done)"
+paths=$(yazi --chooser-file=/dev/stdout | while read -r; do printf "%q " "$REPLY"; done)
 
 if [[ -n "$paths" ]]; then
 	zellij action toggle-floating-panes

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -454,7 +454,9 @@ Then save the following script as `~/.config/helix/yazi-picker.sh`:
 ```sh
 #!/usr/bin/env bash
 
-paths=$(yazi --chooser-file=/dev/stdout | xargs -I {} command printf "%q " {})
+paths="$(yazi --chooser-file=/dev/stdout | while read -r; do
+  command printf '%q ' "$REPLY"
+done)"
 
 if [[ -n "$paths" ]]; then
 	zellij action toggle-floating-panes


### PR DESCRIPTION
Drops using `xargs` in favor of shell built-ins.
Issues with `xargs` were discussed in https://github.com/yazi-rs/yazi-rs.github.io/pull/62