### PR TITLE
docs: fix function in PowerShell at quick start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -72,7 +72,7 @@ function yy {
     yazi $args --cwd-file="$tmp"
     $cwd = Get-Content -Path $tmp
     if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
-        Set-Location -Path $cwd
+        Set-Location -LiteralPath $cwd
     }
     Remove-Item -Path $tmp
 }


### PR DESCRIPTION
`-Path` will leads to error if `$cwd` contains special characters like `[` and `]`, changing to `-LiteralPath` fixes this issue.