### PR TITLE
docs: fix cargo install command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -223,7 +223,7 @@ cargo install --locked yazi-fm yazi-cli
 Or install the latest git version:
 
 ```sh
-cargo install --locked --git https://github.com/sxyazi/yazi.git
+cargo install --locked --git https://github.com/sxyazi/yazi.git yazi-fm yazi-cli
 ```
 
 If it fails to build, please check if `make` and `gcc` is installed on your system.


### PR DESCRIPTION
I think the documentation is obsolete here because if I do this an error is raised:

```
$ cargo install --locked --git https://github.com/sxyazi/yazi.git
    Updating git repository `https://github.com/sxyazi/yazi.git`
error: multiple packages with binaries found: yazi-cli, yazi-fm. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/sxyazi/yazi.git yazi-cli`.
```

But this way it is working:

```
$ cargo install --locked --git https://github.com/sxyazi/yazi.git yazi-fm yazi-cli
    Updating git repository `https://github.com/sxyazi/yazi.git`
     Ignored package `yazi-fm v0.2.5 (https://github.com/sxyazi/yazi.git#07342a29)` is already installed, use --force to override
    Updating git repository `https://github.com/sxyazi/yazi.git`
     Ignored package `yazi-cli v0.2.5 (https://github.com/sxyazi/yazi.git#07342a29)` is already installed, use --force to override
     Summary Successfully installed yazi-fm, yazi-cli!
```