### PR TITLE
docs: do not leak `cwd` variable

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,7 +25,7 @@ We suggest using this `yy` shell wrapper that provides the ability to change the
 
 ```bash
 function yy() {
-	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
 	yazi "$@" --cwd-file="$tmp"
 	if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
 		cd -- "$cwd"


### PR DESCRIPTION
It's good practice for shell functions to local scope their variables