### PR TITLE
docs: add `icons-brew.yazi` to resources page

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -77,6 +77,10 @@ Vim:
 
 - [yazi-prompt.sh](https://github.com/Sonico98/yazi-prompt.sh) - Display an indicator in your prompt when running inside a yazi subshell.
 
+## 🛠️ Utilities
+
+- [icons-brew.yazi](https://github.com/lpnh/icons-brew.yazi) - Make a hot `theme.toml` for your Yazi icons with your favorite color palette.
+
 ## 💖 Add yours
 
 We are so happy to add your plugin to this page!


### PR DESCRIPTION
I though creating a new category would be better than trying to fit it into the existing ones. It seems more like a tool or utility rather than an integrated plugin. In fact, this is one aspect I'm not satisfied about my solution: it requires some extra steps, including manual file handling. However, I couldn't find a more straightforward or simple solution. Anyway, thanks for the awesome work!