### PR TITLE
docs: add zsh.yazi to shell plugins

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -104,6 +104,7 @@ Vim:
 ## 🐚 Shell plugins {#shell}
 
 - [yazi-prompt.sh](https://github.com/Sonico98/yazi-prompt.sh) - Display an indicator in your prompt when running inside a yazi subshell.
+- [zsh.yazi](https://github.com/AnirudhG07/zsh.yazi) - Make Zsh your default shell in yazi.
 
 ## 🛠️ Utilities {#utilities}
 


### PR DESCRIPTION
This is plugin which was made by the maintainer of sxyazi/yazi in an issue regarding aliases in zsh(mentioned and acknowledged in the repo). I believe everyone should know about this. 

Thank you.