### PR TITLE
docs: add augment-command.yazi to the resources page

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -70,6 +70,10 @@ File actions:
 - [bypass.yazi](https://github.com/Rolv-Apneseth/bypass.yazi) - Yazi plugin for skipping directories with only a single sub-directory.
 - [fast-enter.yazi](https://github.com/ourongxing/fast-enter.yazi) - Auto-decompress archives and enter them, or enter the deepest directory until it's not the only subdirectory.
 
+General command enhancements:
+
+- [augment-command.yazi](https://github.com/hankertrix/augment-command.yazi) - Enhances a few Yazi commands with better handling of the choice between selected items and the hovered item. It also auto-extracts archives and has bidirectional skipping of directories with a single sub-directory, while also including quite a few of the plugins on the [tips page](/docs/tips) like `smart-enter`, `smart-paste`, `parent-arrow` and more.
+
 UI enhancements:
 
 - [full-border.yazi](https://github.com/yazi-rs/plugins/tree/main/full-border.yazi) - Add a full border to Yazi to make it look fancier.


### PR DESCRIPTION
This plugin was inspired by [bypass.yazi](https://github.com/Rolv-Apneseth/bypass.yazi) and [fast-enter.yazi](https://github.com/ourongxing/fast-enter.yazi) along with the tips page on the documentation site. It combines all of the features of [bypass.yazi](https://github.com/Rolv-Apneseth/bypass.yazi) and [fast-enter.yazi](https://github.com/ourongxing/fast-enter.yazi) and includes enhancements for some default commands.