### PR TITLE
fix: correct announcement bar height

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,4 +37,5 @@ div[class^="announcementBar_"] {
 	font-size: 20px;
 	background: repeating-linear-gradient(35deg, #e8d7ff, #e8d7ff 20px, #ffe9d1 10px, #ffe9d1 40px) !important;
 	font-weight: 700;
+	height: auto;
 }


### PR DESCRIPTION
Override the announcement bar height to prevent the following behavior:

Before:
<img width="1439" alt="Screenshot 2024-07-14 at 16 02 33" src="https://github.com/user-attachments/assets/a917889f-07fb-412d-985c-6d810ba72fc9">
 
 After
<img width="1439" alt="Screenshot 2024-07-14 at 16 03 13" src="https://github.com/user-attachments/assets/1c1ddc57-d74a-414b-82a7-fc4085ae3b05">

The bug seems to only appear on laptop-sized screens since I tested it on a PC and phone and never saw it.
I also tested it in Safari, Firefox, and Chrome-like browsers.

_P.S. Thank you for Yazi. I'm really enjoying it!_