### PR TITLE
docs: add ya.clipboard to utils

### DIFF
--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -306,6 +306,22 @@ This function is only available on Unix-like systems.
 
 Only available on Unix-like systems. Returns the hostname of the current machine, which is a string if successful; otherwise, `nil`.
 
+### `clipboard(content)` {#ya.clipboard}
+
+Returns the content of clipboard or adds content to the system clipboard.
+
+- `val` - Optional, value to be copied in the clipboard. If not set, will return the value present in the clipboard.
+
+```
+-- get contents of the clipboard
+local content = ya.clipboard()
+
+-- set contents of the clipboard
+ya.clipboard("new clipboard content")
+```
+
+This function is only available in the async context.
+
 ## ps {#ps}
 
 Yazi's DDS (Data Distribution Service) uses a Lua-based publish-subscribe model as its carrier. That is, you can achieve cross-instance communication and state persistence through the `ps` API. See [DDS](/docs/dds) for details.

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -306,11 +306,11 @@ This function is only available on Unix-like systems.
 
 Only available on Unix-like systems. Returns the hostname of the current machine, which is a string if successful; otherwise, `nil`.
 
-### `clipboard(content)` {#ya.clipboard}
+### `clipboard(text)` {#ya.clipboard}
 
 Returns the content of clipboard or adds content to the system clipboard.
 
-- `val` - Optional, value to be copied in the clipboard. If not set, will return the value present in the clipboard.
+- `text` - Optional, value to be copied in the clipboard. If not set, will return the value present in the clipboard.
 
 ```
 -- get contents of the clipboard

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -308,16 +308,16 @@ Only available on Unix-like systems. Returns the hostname of the current machine
 
 ### `clipboard(text)` {#ya.clipboard}
 
-Returns the content of clipboard or adds content to the system clipboard.
+Get or set the content of the system clipboard.
 
-- `text` - Optional, value to be copied in the clipboard. If not set, will return the value present in the clipboard.
+- `text` - Optional, value to be set, which is a string. If not provided, the content of the clipboard will be returned.
 
 ```lua
--- get contents of the clipboard
+-- Get contents from the clipboard
 local content = ya.clipboard()
 
--- set contents of the clipboard
-ya.clipboard("new clipboard content")
+-- Set contents to the clipboard
+ya.clipboard("new content")
 ```
 
 This function is only available in the async context.

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -312,7 +312,7 @@ Returns the content of clipboard or adds content to the system clipboard.
 
 - `text` - Optional, value to be copied in the clipboard. If not set, will return the value present in the clipboard.
 
-```
+```lua
 -- get contents of the clipboard
 local content = ya.clipboard()
 


### PR DESCRIPTION
I have added ya.clipboard docs in the utils. I am very doubtful about 2 things
1) is it only for Unix or not
2) is "text" word usage appropriate or should it be changed?

I hope everything else is fine.