### PR TITLE
docs: specify `cd`-command in bash-zsh shell wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,7 +28,7 @@ function yy() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
 	yazi "$@" --cwd-file="$tmp"
 	if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
-		cd -- "$cwd"
+		builtin cd -- "$cwd"
 	fi
 	rm -f -- "$tmp"
 }


### PR DESCRIPTION
Using `eval "$(zoxide init --cmd cd zsh)"` in my `.zshrc` overrides the `cd` command. Thus the suggested wrapper does not work anymore.