### PR TITLE
docs: add default keybinding for closing tabs

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -218,7 +218,7 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 | <kbd>]</kbd>                                  | Switch to the next tab             |
 | <kbd>\{</kbd>                                 | Swap current tab with previous tab |
 | <kbd>}</kbd>                                  | Swap current tab with next tab     |
-| <kbd>Ctrl</kbd> + <kbd>q</kbd>                | Close the current tab              |
+| <kbd>Ctrl</kbd> + <kbd>q</kbd> (<kbd>Ctrl</kbd> + <kbd>c</kbd> on nightly)                | Close the current tab              |
 
 ## Flavors
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -218,6 +218,7 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 | <kbd>]</kbd>                                  | Switch to the next tab             |
 | <kbd>\{</kbd>                                 | Swap current tab with previous tab |
 | <kbd>}</kbd>                                  | Swap current tab with next tab     |
+| <kbd>Ctrl</kbd> + <kbd>q</kbd>                | Close the current tab              |
 
 ## Flavors
 


### PR DESCRIPTION
This key bind seemed to be missing in the list