### PR TITLE
docs: add yazi-nightly to install from AUR

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,6 +43,12 @@ If you want to use the latest Git version, you can install it from [AUR](https:/
 paru -S yazi-git ffmpegthumbnailer p7zip jq poppler fd ripgrep fzf zoxide imagemagick
 ```
 
+Alternatively, you can install the latest nightly build from [AUR](https://aur.archlinux.org/packages/yazi-nightly-bin):
+
+```sh
+paru -S yazi-nightly-bin ffmpegthumbnailer p7zip jq poppler fd ripgrep fzf zoxide imagemagick
+```
+
 ## Nix
 
 A [Nix package](https://search.nixos.org/packages?channel=unstable&show=yazi) for Yazi is available.


### PR DESCRIPTION
New [nightly tag](https://github.com/sxyazi/yazi/releases/tag/nightly) for pre-build yazi is the game changer.
This PR inform Arch users to install yazi-nightly from AUR.