### PR TITLE
docs: updated shell wrapper for fish in quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -41,7 +41,7 @@ function yy() {
 function yy
 	set tmp (mktemp -t "yazi-cwd.XXXXXX")
 	yazi $argv --cwd-file="$tmp"
-	if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
+	if set cwd (command cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
 		cd -- "$cwd"
 	end
 	rm -f -- "$tmp"


### PR DESCRIPTION
Hi, 

The wrapper for the fish shell was not working for me because I aliased cat to be bat. It added decorated output to the temp file and resulted in an error when trying to cd to the new path. Adding "command" before cat ensures we call the original cat command.

Thanks for the amazing piece of software!