### PR TITLE
Fix key binding for "Close the current tab"

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -218,7 +218,7 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 | <kbd>]</kbd>                                  | Switch to the next tab             |
 | <kbd>\{</kbd>                                 | Swap current tab with previous tab |
 | <kbd>}</kbd>                                  | Swap current tab with next tab     |
-| <kbd>Ctrl</kbd> + <kbd>c</kbd>                | Close the current tab              |
+| <kbd>Ctrl</kbd> + <kbd>q</kbd>                | Close the current tab              |
 
 ## Flavors
 


### PR DESCRIPTION
Change documentation for "Close the current tab" from `Ctrl + c` to `Ctrl + q`, because the tab closes with `Ctrl + q` 🙂