### PR TITLE
Add the method for installing yazi with x-cmd to the documentation.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -331,8 +331,6 @@ If it fails to build, please check if `make` and `gcc` is installed on your syst
 [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
 
 ```sh
-x env use yazi
+x env use yazi fzf 7za jq fd rg zoxide
 ```
-
-Furthermore, x-cmd also supports downloading and installing software tools like fzf, 7-Zip(7za), jq, fd, rg, and zoxide.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -325,3 +325,14 @@ Then, you can run:
 ```
 
 If it fails to build, please check if `make` and `gcc` is installed on your system.
+
+## x-cmd
+
+[x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
+
+```sh
+x env use yazi
+```
+
+Furthermore, x-cmd also supports downloading and installing software tools like fzf, 7-Zip(7za), jq, fd, rg, and zoxide.
+


### PR DESCRIPTION
Hi, can I add a section to the installation.md documentation explaining how to install Yazi using x-cmd?
- [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
```sh
x env use yazi fzf 7za jq fd rg zoxide
```
- Furthermore, x-cmd also supports downloading and installing software tools like fzf, 7-Zip(7za), jq, fd, rg, and zoxide.
