### PR TITLE
docs: add `yy` command support for cmd.exe (Command Prompt)

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -79,6 +79,27 @@ function yy {
 ```
 
   </TabItem>
+  <TabItem value="command-prompt" label="Command Prompt">
+
+Create the file `yy.cmd` and place it in your `%PATH%`.
+
+```cmd
+@echo off
+
+set tmpfile=%TEMP%\tempfile.txt
+
+yazi %* --cwd-file="%tmpfile%"
+
+set /p cwd=<%tmpfile%
+
+if not "%cwd%"=="" (
+    cd /d "%cwd%"
+)
+
+del "%tmpfile%"
+```
+
+  </TabItem>
 </Tabs>
 
 To use it, copy the function into the configuration file of your respective shell. Then use `yy` instead of `yazi` to start.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -86,7 +86,7 @@ Create the file `yy.cmd` and place it in your `%PATH%`.
 ```cmd
 @echo off
 
-set tmpfile=%TEMP%\tempfile.txt
+set tmpfile=%TEMP%\yazi-cwd.%random%
 
 yazi %* --cwd-file="%tmpfile%"
 


### PR DESCRIPTION
Many people prefer `cmd.exe` instead of Windows Terminal or PowerShell because `cmd.exe` is faster and it's possible to have all the great features of Windows Terminal / PowerShell with [clink](https://github.com/chrisant996/clink)