### PR TITLE
docs: specify `cd`-command in fish shell wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,7 +42,7 @@ function yy
 	set tmp (mktemp -t "yazi-cwd.XXXXXX")
 	yazi $argv --cwd-file="$tmp"
 	if set cwd (command cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
-		cd -- "$cwd"
+		builtin cd -- "$cwd"
 	end
 	rm -f -- "$tmp"
 end


### PR DESCRIPTION
Makes the wrapper work with `zoxide init fish --cmd cd | source` in fish config.
Same as https://github.com/yazi-rs/yazi-rs.github.io/pull/108, but for `fish`