### PR TITLE
docs: add copy-file-contents.yazi

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -83,6 +83,7 @@ File actions:
 
 Clipboard:
 
+- [copy-file-contents.yazi](https://github.com/AnirudhG07/plugins-yazi/tree/main/copy-file-contents.yazi) - A simple plugin to copy file contents just from Yazi without going into editor.
 - [simple-clipboard.yazi](https://github.com/orhnk/system-clipboard.yazi) - Cross platform implementation of a simple system clipboard.
 
 `filter` enhancements:


### PR DESCRIPTION
This is a plugin for copying file contents from yazi. I tested out "Tips" section, a couple of previously made plugins but nothing worked. So i whipped up this, very simple and straightforward.
I hope it could be added to the list.

Thanks!