### PR TITLE
docs(quick-start): fix aliased cat error on shell wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -27,7 +27,7 @@ We suggest using this `y` shell wrapper that provides the ability to change the 
 function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
 	yazi "$@" --cwd-file="$tmp"
-	if cwd="$(\cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+	if cwd="$(command cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
 		builtin cd -- "$cwd"
 	fi
 	rm -f -- "$tmp"

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -27,7 +27,7 @@ We suggest using this `y` shell wrapper that provides the ability to change the 
 function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
 	yazi "$@" --cwd-file="$tmp"
-	if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+	if cwd="$(\cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
 		builtin cd -- "$cwd"
 	fi
 	rm -f -- "$tmp"


### PR DESCRIPTION
If users have aliased cat to bat, and have line numbers enabled, the zsh/bash y script will fail

Using \cat to target builtin cat (builtin didn't seem to work, command does but doesn't appear to be cross compatible across bash & zsh)

![image](https://github.com/user-attachments/assets/305165d0-746e-4ba6-955a-30ff8bc75ead)
