### PR TITLE
docs: clarify `tab_size` definition in configuration

### DIFF
--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -147,7 +147,7 @@ Wrap long lines in the code preview.
 
 ### `tab_size` {#preview.tab_size}
 
-The width of a tab character in spaces.
+The width of a tab character (`\t`) in spaces.
 
 ### `max_width` {#preview.max_width}
 

--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -147,7 +147,7 @@ Wrap long lines in the code preview.
 
 ### `tab_size` {#preview.tab_size}
 
-Tab width.
+The width of a tab character in spaces.
 
 ### `max_width` {#preview.max_width}
 


### PR DESCRIPTION
Specify that `tab_size` refers to the width of a tab character, not a tab in the context of a user interface, which is often used to navigate between different views or sections.