### PR TITLE
docs: add simple-mtpfs.yazi plugin

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -85,6 +85,7 @@ File actions:
 - [lazygit.yazi](https://github.com/Lil-Dank/lazygit.yazi) - Manage Git directories with [lazygit](https://github.com/jesseduffield/lazygit) with a quick shortcut.
 - [sudo.yazi](https://github.com/TD-Sky/sudo.yazi) - Execute specific file operations with `sudo` privileges.
 - [restore.yazi](https://github.com/boydaihungst/restore.yazi) - Restore/recover latest deleted files/folders using `trash-cli`.
+- [simple-mtpfs.yazi](https://github.com/boydaihungst/simple-mtpfs.yazi) -  Mounting MTP devices (Android, Camera, etc) using `simple-mtpfs` (for Linux only).
 
 Clipboard:
 


### PR DESCRIPTION
Add simple-mtpfs.yazi plugin to 🧩 Functional plugins > File actions. Mounting MTP devices (Android, Camera, etc) in yazi, using simple-mtpfs. 
![image](https://github.com/user-attachments/assets/d371302f-87c5-4936-9408-f62ed0728be5)
List devices
![image](https://github.com/user-attachments/assets/eb7688cd-9a54-40c7-b0e7-2b20e938f067)
![image](https://github.com/user-attachments/assets/798aaed9-a470-4608-b043-ded5dd16e32e)
