### PR TITLE
docs: fix TEMP path with spaces error on shell wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -90,7 +90,7 @@ set tmpfile=%TEMP%\yazi-cwd.%random%
 
 yazi %* --cwd-file="%tmpfile%"
 
-set /p cwd=<%tmpfile%
+set /p cwd=<"%tmpfile%"
 
 if not "%cwd%"=="" (
     cd /d "%cwd%"


### PR DESCRIPTION
My computer name has a space in it and the Command Prompt wrapper doesn't work. This fixes the error.
![image](https://github.com/user-attachments/assets/493e5fc6-27e3-4339-98f0-e4ecf08336e2)