### PR TITLE
docs: introduce missing items

### DIFF
--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -83,7 +83,7 @@ Cancel find, exit visual mode, clear selected, cancel filter, or cancel search.
 
 | Argument/Option | Description          |
 | --------------- | -------------------- |
-| `--all`         | Do all of the below. |
+| `--all`         | Do all the below.    |
 | `--find`        | Cancel find.         |
 | `--visual`      | Exit visual mode.    |
 | `--select`      | Clear selected.      |
@@ -103,6 +103,12 @@ Exit the process.
 ### `close` {#manager.close}
 
 Close the current tab; if it's the last tab, exit the process instead.
+
+### `suspend` {#manager.suspend}
+
+Pauses Yazi and returns to the parent shell to continue with other tasks.
+
+Once those tasks are done, use the `fg` command of the shell to send a resume signal and return back to Yazi.
 
 ### `arrow` {#manager.arrow}
 
@@ -271,7 +277,7 @@ Paste the yanked files.
 
 ### `link` {#manager.link}
 
-Create a symbolic link to the yanked files. (This is a privileged action in Windows and must be run as an administrator.)
+Create a symbolic link to the yanked files. (This is a privileged action on Windows and must be run as an administrator.)
 
 | Argument/Option | Description                                  |
 | --------------- | -------------------------------------------- |
@@ -349,7 +355,7 @@ Run a shell command.
 | `--block`       | Open in a blocking manner. After setting this, Yazi will hide into a secondary screen and display the program on the main screen until it exits. During this time, it can receive I/O signals, which is useful for interactive programs. |
 | `--orphan`      | Keep the process running even if Yazi has exited, once specified, the process will be detached from the task scheduling system.                                                                                                          |
 | `--confirm`     | When the template is provided, run it directly, no input box was shown. It's mutually exclusive with `--interactive`.                                                                                                                    |
-| `--interactive` | Request the user to input the command to be ran interactively. It's mutually exclusive with `--confirm`.                                                                                                                                 |
+| `--interactive` | Request the user to input the command to be run interactively. It's mutually exclusive with `--confirm`.                                                                                                                                 |
 | `--cursor`      | Set the initial position of the cursor in the interactive command input box. For example, `shell 'zip -r .zip "$0"' --cursor=7 --interactive` places the cursor before `.zip`.                                                           |
 
 You can use the following shell variables in `[run]`:
@@ -591,7 +597,7 @@ Move the cursor left or right.
 | Argument/Option  | Description                                                                                      |
 | ---------------- | ------------------------------------------------------------------------------------------------ |
 | `[n]`            | Move the cursor `n` characters left or right. Negative value for left, positive value for right. |
-| `--in-operating` | Move the cursor only if its currently waiting for an operation.                                  |
+| `--in-operating` | Move the cursor only if it's currently waiting for an operation.                                  |
 
 ### `backward` {#input.backward}
 
@@ -676,6 +682,28 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin). This command 
 ### `noop` {#input.noop}
 
 See [`noop` command](#manager.noop).
+
+## [confirm] {#confirm}
+
+### `close` {#confirm.close}
+
+Cancel and close the confirmation dialog.
+
+| Argument/Option | Description            |
+| --------------- | ---------------------- |
+| `--submit`      | Submit the confirmation. |
+
+### `arrow` {#confirm.arrow}
+
+Move the confirmation cursor.
+
+| Argument/Option | Description                                                                           |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `[n]`           | Move the cursor up or down `n` lines. Negative value for up, positive value for down. |
+
+### `help` {#confirm.help}
+
+Open the help menu.
 
 ## [completion] {#completion}
 

--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -83,8 +83,8 @@ Tab: Tab bar.
 Count: Counters.
 
 - count_copied (Style): Style of copied file number.
-- count_cut (Style): Number of cut files.
-- count_selected (Style): Number of selected files.
+- count_cut (Style): Style of cut file number.
+- count_selected (Style): Style of selected file number.
 
 Border:
 
@@ -176,9 +176,9 @@ Icons
 
 Title: Notification title.
 
-- title_info (Style): Info notification.
-- title_warn (Style): Warning notification.
-- title_error (Style): Error notification.
+- title_info (Style): Style of the info title.
+- title_warn (Style): Style of the warning title.
+- title_error (Style): Style of the error title.
 
 Icon: Notification icon.
 

--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -74,11 +74,17 @@ Marker: Color block on the left side separator line in the filename.
 - marker_marked (Style): Marker style of pre-selected file in visual mode.
 - marker_selected (Style): Selected file marker style.
 
-Tab: Tab bar
+Tab: Tab bar.
 
 - tab_active (Style): Active tab style.
 - tab_inactive (Style): Inactive tab style.
 - tab_width (Number): Tab maximum width. When set to a value greater than 2, the remaining space will be filled with the tab name, which is current directory name.
+
+Count: Counters.
+
+- count_copied (Style): Style of copied file number.
+- count_cut (Style): Number of cut files.
+- count_selected (Style): Number of selected files.
 
 Border:
 
@@ -165,6 +171,20 @@ Icons
 - desc (Style): Description column style.
 - hovered (Style): Hovered item style.
 - footer (Style): Footer style.
+
+## [notify] {#notify}
+
+Title: Notification title.
+
+- title_info (Style): Info notification.
+- title_warn (Style): Warning notification.
+- title_error (Style): Error notification.
+
+Icon: Notification icon.
+
+- icon_info (String): Info icon.
+- icon_warn (String): Warning icon.
+- icon_error (String): Error icon.
 
 ## [filetype] {#filetype}
 
@@ -263,7 +283,7 @@ Icons are matched according to the following priority:
 For more complex and precise rules, such as matching a specific file in a specific directory, use `globs` - these are always executed first to check if any rules in the glob set are met.
 However, they are much slower than `dirs`, `files`, and `exts`, so it's not recommended to use them excessively.
 
-If none of the above rules match, it will fallback to `conds` to check if any specific conditions are met. `conds` are mostly used for rules related to file metadata, which includes the following conditional factors:
+If none of the above rules match, it will fall back to `conds` to check if any specific conditions are met. `conds` are mostly used for rules related to file metadata, which includes the following conditional factors:
 
 - `dir`: The file is a directory
 - `hidden`: The file is hidden

--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -325,8 +325,10 @@ An array of `[width, height]`, maximum image size (in pixels) for decoding a sin
 ### fetchers {#plugin.fetchers}
 
 :::warning
-Fetchers are not complete yet and will undergo further changes!
+Fetchers are not complete yet, and the API is subject to change without prior notice!
 :::
+
+TODO
 
 You can prepend or append new fetchers to the default `fetchers` under `[plugin]` by `prepend_fetchers` and `append_fetchers`, see [Configuration mixing](/docs/configuration/overview#mixing) for details.
 Here are the available options for a single rule:
@@ -408,17 +410,17 @@ If you want to create your own preloader, see [Preloader API](/docs/plugins/over
 
 ## [input] {#input}
 
-You can customize the title and position of each input. There are following inputs: `cd`, `create`, `rename`, `filter`, `find`, `search` and `shell`. To change their configuration use the underscore between the name and the option, like `cd_origin`.
-
-As for position, it consists of two parts: [Origin](#input.origin) and [Offset](#input.offset).
-The origin is the top-left corner of the input, and the offset is the increment from this origin. Together, they determine the area of the input on the screen.
-
-### Cursor blink {#input.cursor_blink}
+### `cursor_blink` {#input.cursor_blink}
 
 Control the cursor blinking.
 
 - `true`: Blink.
 - `false`: Do not blink.
+
+You can customize the title and position of each input. There are following inputs: `cd`, `create`, `rename`, `filter`, `find`, `search` and `shell`. To change their configuration use the underscore between the name and the option, like `cd_origin`.
+
+As for position, it consists of two parts: [Origin](#input.origin) and [Offset](#input.offset).
+The origin is the top-left corner of the input, and the offset is the increment from this origin. Together, they determine the area of the input on the screen.
 
 ### Origin {#input.origin}
 
@@ -509,12 +511,3 @@ This is useful for files that contain Hungarian characters.
 
 - `true`: Enabled
 - `false`: Disabled
-
-## [log] {#log}
-
-### `enabled` {#log.enabled}
-
-Whether to enable logging.
-
-- `true`: Enable logging.
-- `false`: Disable logging.

--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -285,8 +285,8 @@ rules = [
 
 Available rule options are as follows:
 
-- `name`: Glob expression for matching the file name. Case insensitive by default, add `\s` to the beginning to make it sensitive.
-- `mime`: Glob expression for matching the mime-type. Case insensitive by default, add `\s` to the beginning to make it sensitive.
+- `name`: Glob expression for matching the file name. Case-insensitive by default, add `\s` to the beginning to make it sensitive.
+- `mime`: Glob expression for matching the mime-type. Case-insensitive by default, add `\s` to the beginning to make it sensitive.
 - `use`: Opener name corresponding to the names in the [`[opener]` section](#opener).
 
 With that:
@@ -322,14 +322,29 @@ An array of `[width, height]`, maximum image size (in pixels) for decoding a sin
 
 ## [plugin] {#plugin}
 
+### fetchers {#plugin.fetchers}
+
+:::warning
+Fetchers are not complete yet and will undergo further changes!
+:::
+
+You can prepend or append new fetchers to the default `fetchers` under `[plugin]` by `prepend_fetchers` and `append_fetchers`, see [Configuration mixing](/docs/configuration/overview#mixing) for details.
+Here are the available options for a single rule:
+
+- `id` (String): Fetcher's ID.
+- `name` (String): Glob expression for matching the file name. Case-insensitive by default, add `\s` to the beginning to make it sensitive.
+- `run` (String): The name of the Lua plugin to be run.
+- `if` (String): Execute the fetcher based on this condition.
+- `prio` (String): The priority of the task. One of `high`, `normal` or `low`.
+
 ### previewers {#plugin.previewers}
 
 You can prepend or append new preview rules to the default `previewers` under `[plugin]` by `prepend_previewers` and `append_previewers`, see [Configuration mixing](/docs/configuration/overview#mixing) for details.
 Here are the available options for a single rule:
 
-- `name` (String): Glob expression for matching the file name. Case insensitive by default, add `\s` to the beginning to make it sensitive.
-- `mime` (String): Glob expression for matching the mime-type. Case insensitive by default, add `\s` to the beginning to make it sensitive.
-- `run` (String): The name of the Lua plugin to be ran.
+- `name` (String): Glob expression for matching the file name. Case-insensitive by default, add `\s` to the beginning to make it sensitive.
+- `mime` (String): Glob expression for matching the mime-type. Case-insensitive by default, add `\s` to the beginning to make it sensitive.
+- `run` (String): The name of the Lua plugin to be run.
 - `sync` (Boolean): Whether to run in the sync context, default is `false`.
 
 ```toml
@@ -365,11 +380,11 @@ If you want to create your own previewer, see [Previewer API](/docs/plugins/over
 You can prepend or append new preview rules to the default `preloaders` under `[plugin]` by `prepend_preloaders` and `append_preloaders`, see [Configuration mixing](/docs/configuration/overview#mixing) for details.
 Here are the available options for a single rule:
 
-- `name` (String): Glob expression for matching the file name. Case insensitive by default, add `\s` to the beginning to make it sensitive.
-- `mime` (String): Glob expression for matching the mime-type. Case insensitive by default, add `\s` to the beginning to make it sensitive.
+- `name` (String): Glob expression for matching the file name. Case-insensitive by default, add `\s` to the beginning to make it sensitive.
+- `mime` (String): Glob expression for matching the mime-type. Case-insensitive by default, add `\s` to the beginning to make it sensitive.
 - `cond` (String): Conditional expression – Only rules that meet this condition and satisfy either the `name` or `mime` will be applied. For example, `A & B` means A and B, and `A | !B` means A or not B. Here are the available factors:
   - `mime`: This file has a mime-type.
-- `run` (String): The name of the Lua plugin to be ran.
+- `run` (String): The name of the Lua plugin to be run.
 - `multi` (Boolean): Whether to preload multiple files at once.
 - `prio` (String): Preload priority, `low`, `normal` or `high`. The default is `normal` if not specified.
 
@@ -393,9 +408,17 @@ If you want to create your own preloader, see [Preloader API](/docs/plugins/over
 
 ## [input] {#input}
 
-You can customize the title and position of each input. As for position, it consists of two parts: [Origin](#input.origin) and [Offset](#input.offset).
+You can customize the title and position of each input. There are following inputs: `cd`, `create`, `rename`, `filter`, `find`, `search` and `shell`. To change their configuration use the underscore between the name and the option, like `cd_origin`.
 
+As for position, it consists of two parts: [Origin](#input.origin) and [Offset](#input.offset).
 The origin is the top-left corner of the input, and the offset is the increment from this origin. Together, they determine the area of the input on the screen.
+
+### Cursor blink {#input.cursor_blink}
+
+Control the cursor blinking.
+
+- `true`: Blink.
+- `false`: Do not blink.
 
 ### Origin {#input.origin}
 
@@ -448,11 +471,11 @@ Some inputs have special placeholders that will be replaced with actual content 
 
 ## [confirm] {#confirm}
 
-TODO
+Same as the [`[input]`](#input) section. There are a few available: `trash`, `delete`, `overwrite` and `quit`.
 
 ## [select] {#select}
 
-Same as the [`[input]`](#input) section.
+Same as the [`[input]`](#input) section. Available selectors: `open`.
 
 ## [which] {#which}
 
@@ -486,3 +509,12 @@ This is useful for files that contain Hungarian characters.
 
 - `true`: Enabled
 - `false`: Disabled
+
+## [log] {#log}
+
+### `enabled` {#log.enabled}
+
+Whether to enable logging.
+
+- `true`: Enable logging.
+- `false`: Disable logging.


### PR DESCRIPTION
What I did: 
1. Compared v0.3.3 sources with existing docs.
2. Added all missing items that I could find.
3. Spell check.

What I did not:
1. Renamed `select` to `pick` - this is upcoming change, I don't want to interfere with releases. But if you wish, I could do that.

Needs attention:
1. `plugin.fetchers`. I never used it, but I did my best to assume stuff based on sources. I'd appreciate if someone could take a glance at what I wrote there.