### PR TITLE
docs: document new APIs

### DIFF
--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -369,7 +369,7 @@ If your `append_previewers` contains wildcard `name` rules (`"*"` or `"*/"`), th
 
 Yazi comes with the these previewer plugins:
 
-- folder: bridge between the Yazi file system and the preview
+- folder: bridge between the Yazi filesystem and the preview
 - code: bridge between built-in code highlighting and the preview, providing async concurrent rendering
 - json: bridge between `jq` and the preview, providing async concurrent rendering
 - noop: no operation

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -230,6 +230,14 @@ This function is only available in the async context.
 
 This function is only available in the async context.
 
+### `target_family()` {#ya.target_family}
+
+Returns the family of the operating system. Some possible values:
+
+- `"unix"`
+- `"windows"`
+- `"wasm"`
+
 ### `target_os()` {#ya.target_os}
 
 Returns a string describing the specific operating system in use. Some possible values:
@@ -244,14 +252,6 @@ Returns a string describing the specific operating system in use. Some possible 
 - `"solaris"`
 - `"android"`
 - `"windows"`
-
-### `target_family()` {#ya.target_family}
-
-Returns the family of the operating system. Some possible values:
-
-- `"unix"`
-- `"windows"`
-- `"wasm"`
 
 ### `hash(str)` {#ya.hash}
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -511,9 +511,9 @@ Returns `(cha, err)`:
 local url, err = fs.cwd()
 ```
 
-This function was added to compensate for the lack of a `getcwd` in Lua; it is used to retrieve the directory of the last `chdir` call.
+This function was added to compensate for the lack of a [`getcwd`][getcwd] in Lua; it is used to retrieve the directory of the last [`chdir`][chdir] call.
 
-You probably will never need it, and more likely, you'll need `cx.active.current.cwd`, which is the current directory where the user is working.
+You probably will never need it, and more likely, you'll need [`cx.active.current.cwd`][folder-folder], which is the current directory where the user is working.
 
 Specifically, when the user changes the directory, `cx.active.current.cwd` gets updated immediately, while synchronizing this update with the filesystem via `chdir` involves I/O operations, such as checking if the directory is valid.
 
@@ -525,6 +525,10 @@ Returns `(url, err)`:
 - `err`: The error code if the operation is failed, which is an integer if any.
 
 It is useful if you just need a valid directory as the CWD of a process to start some work that doesn't depend on the CWD.
+
+[getcwd]: https://man7.org/linux/man-pages/man3/getcwd.3.html
+[chdir]: https://man7.org/linux/man-pages/man2/chdir.2.html
+[folder-folder]: /docs/plugins/types#app-data.folder-folder
 
 ### `create(type, url)` {#fs.create}
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -29,19 +29,27 @@ This function is only available in the async context.
 
 Calculate the cached [Url](/docs/plugins/types#shared.url) corresponding to the given file:
 
-- `opts` - Required, the options of the cache, which is a table:
+- `opts`: Required, the options of the cache, which is a table:
 
-  - `file` - The [File](/docs/plugins/types#shared.file) to be cached
-  - `skip` - The number of units to skip. It's units largely depend on your previewer, such as lines for code, and percentages for videos
+  - `file`: The [File](/docs/plugins/types#shared.file) to be cached.
+  - `skip`: The number of units to skip. It's units largely depend on your previewer, such as lines for code, and percentages for videos.
 
 If the file is not allowed to be cached, such as it's ignored in the user config, or the file itself is a cache, returns `nil`.
+
+### `render()` {#ya.render}
+
+```lua
+ya.render()
+```
+
+Re-render Yazi's UI.
 
 ### `manager_emit(cmd, args)` {#ya.manager_emit}
 
 Send a command to the [`[manager]`](/docs/configuration/keymap#manager) without waiting for the executor to execute:
 
-- `cmd` - Required, the command name, which is a string
-- `args` - Required, the arguments of the command, which is a table with a number or string key and [sendable values](/docs/plugins/overview#sendable)
+- `cmd`: Required, the command name, which is a string.
+- `args`: Required, the arguments of the command, which is a table with a number or string key and [sendable values](/docs/plugins/overview#sendable).
 
 ```lua
 ya.manager_emit("my-cmd", { "hello", 123, foo = true, bar_baz = "world" })
@@ -54,8 +62,8 @@ ya.manager_emit("my-cmd", { "hello", 123, foo = true, bar_baz = "world" })
 
 Display the given image within the specified area, and the image will downscale to fit that area automatically:
 
-- `url` - Required, the [Url](/docs/plugins/types#shared.url) of the image
-- `rect` - Required, the [Rect](/docs/plugins/layout#rect) of the area
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the image.
+- `rect`: Required, the [Rect](/docs/plugins/layout#rect) of the area.
 
 This function is only available in the async context.
 
@@ -63,8 +71,8 @@ This function is only available in the async context.
 
 Pre-cache the image to a specified url based on user-configured [`max_width` and `max_height`](/docs/configuration/yazi#preview):
 
-- `src` - Required, the source [Url](/docs/plugins/types#shared.url) of the image
-- `dist` - Required, the destination [Url](/docs/plugins/types#shared.url) of the image
+- `src`: Required, the source [Url](/docs/plugins/types#shared.url) of the image.
+- `dist`: Required, the destination [Url](/docs/plugins/types#shared.url) of the image.
 
 This function is only available in the async context.
 
@@ -74,9 +82,9 @@ Prompt users with a set of available keys:
 
 - `opts`: Required, the options of the prompt, which is a table:
   - `cands`: Required, the key candidates, which is a table of tables that contains the following fields:
-    - `on`: Required, the key to be prompted, which is a string or a table of strings if multiple keys
-    - `desc`: Optional, the description of the key, which is a string
-  - `silent`: Optional, whether to show the UI of key indicator, which is a boolean
+    - `on`: Required, the key to be prompted, which is a string or a table of strings if multiple keys.
+    - `desc`: Optional, the description of the key, which is a string.
+  - `silent`: Optional, whether to show the UI of key indicator, which is a boolean.
 
 ```lua
 local cand = ya.which {
@@ -120,8 +128,8 @@ local value, event = ya.input {
 
 Returns `(value, event)`:
 
-- `value` - The user input value carried by this event, which is a string if the `event` is non-zero; otherwise, `nil`.
-- `event` - The event type, which is an integer:
+- `value`: The user input value carried by this event, which is a string if the `event` is non-zero; otherwise, `nil`.
+- `event`: The event type, which is an integer:
   - 0: Unknown error.
   - 1: The user has confirmed the input.
   - 2: The user has canceled the input.
@@ -171,7 +179,7 @@ ya.notify {
 
 Append messages to [the log file](/docs/plugins/overview#logging) at the debug level:
 
-- `msg` - Required, the message to be logged.
+- `msg`: Required, the message to be logged.
 
 ```lua
 ya.dbg("Hello", "World!")                       -- Multiple arguments are supported
@@ -184,7 +192,7 @@ Note that if you use a release build of Yazi, the log level is "error" instead o
 
 Append messages to [the log file](/docs/plugins/overview#logging) at the error level:
 
-- `msg` - Required, the message to be logged.
+- `msg`: Required, the message to be logged.
 
 ```lua
 ya.err("Hello", "World!")                       -- Multiple arguments are supported
@@ -199,36 +207,28 @@ See [Async context](/docs/plugins/overview#async-context).
 
 Preview the file as code into the specified area:
 
-- `opts` - Required, the options of the preview, which is a table:
-  - `file` - The previewed [File](/docs/plugins/types#shared.file)
-  - `area` - The area of the preview, which is a [Rect](/docs/plugins/layout#rect)
-  - `skip` - The number of units to skip. It's units largely depend on your previewer, such as lines for code, and percentages for videos
-  - `window` - The [Window](/docs/plugins/types#shared.window) of the preview
+- `opts`: Required, the options of the preview, which is a table:
+  - `file`: The previewed [File](/docs/plugins/types#shared.file).
+  - `area`: The area of the preview, which is a [Rect](/docs/plugins/layout#rect).
+  - `skip`: The number of units to skip. It's units largely depend on your previewer, such as lines for code, and percentages for videos.
+  - `window`: The [Window](/docs/plugins/types#shared.window) of the preview.
 
 Returns `(err, upper_bound)`:
 
-- `err` - Error string if the preview fails; otherwise, `nil`.
-- `upper_bound` - If the preview fails and it's because exceeds the maximum upper bound, return this bound; otherwise, `nil`.
+- `err`: Error string if the preview fails; otherwise, `nil`.
+- `upper_bound`: If the preview fails and it's because exceeds the maximum upper bound, return this bound; otherwise, `nil`.
 
 This function is only available in the async context.
 
 ### `preview_widgets(opts, widgets)` {#ya.preview_widgets}
 
-- `opts` - Required, the options of the preview, which is a table:
-  - `file` - The previewed [File](/docs/plugins/types#shared.file)
-  - `skip` - The number of units to skip. It's units largely depend on your previewer, such as lines for code, and percentages for videos
-  - `window` - The [Window](/docs/plugins/types#shared.window) of the preview
-- `widgets` - List of renderable widgets, such as `{ ui.Text {...}, ui.List {...}, ... }`
+- `opts`: Required, the options of the preview, which is a table:
+  - `file`: The previewed [File](/docs/plugins/types#shared.file).
+  - `skip`: The number of units to skip. It's units largely depend on your previewer, such as lines for code, and percentages for videos.
+  - `window`: The [Window](/docs/plugins/types#shared.window) of the preview.
+- `widgets`: List of renderable widgets, such as `{ ui.Text {...}, ui.List {...}, ... }`.
 
 This function is only available in the async context.
-
-### `target_family()` {#ya.target_family}
-
-Returns the family of the operating system. Some possible values:
-
-- `"unix"`
-- `"windows"`
-- `"wasm"`
 
 ### `target_os()` {#ya.target_os}
 
@@ -245,24 +245,58 @@ Returns a string describing the specific operating system in use. Some possible 
 - `"android"`
 - `"windows"`
 
+### `target_family()` {#ya.target_family}
+
+Returns the family of the operating system. Some possible values:
+
+- `"unix"`
+- `"windows"`
+- `"wasm"`
+
+### `hash(str)` {#ya.hash}
+
+```lua
+ya.hash("test.txt")
+```
+
+Returns the MD5 hash of a given string, which is a `string`.
+
+- `str`: Required, the string to calculate the MD5 hash for.
+
 ### `quote(str)` {#ya.quote}
-
-Quote characters that may have special meaning in a shell:
-
-- `str`: Required, the string to be quoted
 
 ```lua
 local handle = io.popen("ls " .. ya.quote(filename))
 ```
 
+Quote characters that may have special meaning in a shell:
+
+- `str`: Required, the string to be quoted.
+
 ### `truncate(text, opts)` {#ya.truncate}
 
 Truncate the text to the specified length and return it:
 
-- `text` - Required, the text to be truncated, which is a string.
-- `opts` - Required, the options of the truncation, which is a table:
-  - `max` - Required, the maximum length of the text, which is an integer.
-  - `rtl` - Optional, whether the text is right-to-left, which is a boolean.
+- `text`: Required, the text to be truncated, which is a string.
+- `opts`: Required, the options of the truncation, which is a table:
+  - `max`: Required, the maximum length of the text, which is an integer.
+  - `rtl`: Optional, whether the text is right-to-left, which is a boolean.
+
+### `clipboard(text)` {#ya.clipboard}
+
+Get or set the content of the system clipboard.
+
+- `text`: Optional, value to be set, which is a string. If not provided, the content of the clipboard will be returned.
+
+```lua
+-- Get contents from the clipboard
+local content = ya.clipboard()
+
+-- Set contents to the clipboard
+ya.clipboard("new content")
+```
+
+This function is only available in the async context.
 
 ### `time()` {#ya.time}
 
@@ -272,7 +306,7 @@ Returns the current timestamp, which is a float, the integer part represents the
 
 Waits until `secs` has elapsed:
 
-- `secs`: Required, the number of seconds to sleep, which is a positive float
+- `secs`: Required, the number of seconds to sleep, which is a positive float.
 
 ```lua
 ya.sleep(0.5)  -- Sleep for 500 milliseconds
@@ -292,7 +326,7 @@ Only available on Unix-like systems. Returns the group id of the current user, w
 
 Get the name of the user:
 
-- `uid` - Optional, the user id of the user, which is an integer. If not set, it will use the current user's id.
+- `uid`: Optional, the user id of the user, which is an integer. If not set, it will use the current user's id.
 
 Returns the name of the current user, which is a string if successful; otherwise, `nil`.
 
@@ -302,7 +336,7 @@ This function is only available on Unix-like systems.
 
 Get the name of the user group:
 
-- `gid` - Optional, the group id of the user, which is an integer. If not set, it will use the current user's group id.
+- `gid`: Optional, the group id of the user, which is an integer. If not set, it will use the current user's group id.
 
 Returns the name of the current group, which is a string if successful; otherwise, `nil`.
 
@@ -311,22 +345,6 @@ This function is only available on Unix-like systems.
 ### `host_name()` {#ya.host_name}
 
 Only available on Unix-like systems. Returns the hostname of the current machine, which is a string if successful; otherwise, `nil`.
-
-### `clipboard(text)` {#ya.clipboard}
-
-Get or set the content of the system clipboard.
-
-- `text` - Optional, value to be set, which is a string. If not provided, the content of the clipboard will be returned.
-
-```lua
--- Get contents from the clipboard
-local content = ya.clipboard()
-
--- Set contents to the clipboard
-ya.clipboard("new content")
-```
-
-This function is only available in the async context.
 
 ## ps {#ps}
 
@@ -342,8 +360,8 @@ ps.pub("greeting", "Hello, World!")
 
 Publish a message to the current instance, and all plugins subscribed through `sub()` for this `kind` will receive it, achieving internal communication within the instance:
 
-- `kind` - Required, the kind of the message, which is a string of alphanumeric with dashes, and cannot be [built-in kinds](/docs/dds#builtin).
-- `value` - Required, the value of the message, which is a [sendable value](/docs/plugins/overview#sendable)
+- `kind`: Required, the kind of the message, which is a string of alphanumeric with dashes, and cannot be [built-in kinds](/docs/dds#builtin).
+- `value`: Required, the value of the message, which is a [sendable value](/docs/plugins/overview#sendable).
 
 Since the `kind` is used globally, to add the plugin name as the prefix is a best practice. For example, the combination of the plugin `my-plugin` and the kind `event1` would be `my-plugin-event1`.
 
@@ -360,9 +378,9 @@ Publish a message to a specific instance with `receiver` as the ID:
 
 With:
 
-- `receiver` - Required, ID of the remote instance, which is a integer; if it's `0` then broadcasting to all remote instances
-- `kind` - The same as `pub()`
-- `value` - The same as `pub()`
+- `receiver`: Required, ID of the remote instance, which is a integer; if it's `0` then broadcasting to all remote instances.
+- `kind`: The same as `pub()`.
+- `value`: The same as `pub()`.
 
 ### `sub(kind, callback)` {#ps.sub}
 
@@ -374,10 +392,9 @@ end)
 
 Subscribe to local messages of `kind` and call the `callback` handler for it:
 
-- `kind` - Required, the kind of the message, which is a string
-- `callback` - Required, the callback function, with a single parameter `body` containing the content of the message
-
-which runs in a sync context, so you can access app data via `cx` for the content of interest.
+- `kind`: Required, the kind of the message, which is a string.
+- `callback`: Required, the callback function, with a single parameter `body` containing the content of the message.
+  It runs in a sync context, so you can access app data via `cx` for the content of interest.
 
 Note: No time-consuming operations should be done in the callback, and the same `kind` from the same plugin can only be subscribed once, re-subscribing (`sub()`) before unsubscribing (`unsub()`) will throw an error.
 
@@ -393,7 +410,7 @@ ps.unsub("my-message")
 
 Unsubscribe from local messages of this `kind`:
 
-- `kind` - Required, the kind of the message, which is a string
+- `kind`: Required, the kind of the message, which is a string.
 
 ### `unsub_remote(kind)` {#ps.unsub_remote}
 
@@ -403,66 +420,32 @@ ps.unsub_remote("my-message")
 
 Unsubscribe from remote messages of this `kind`:
 
-- `kind` - Required, the kind of the message, which is a string
+- `kind`: Required, the kind of the message, which is a string.
 
 ## fs
 
 The following functions can only be used within an async context.
 
-### `write(url, data)` {#fs.write}
+### `cwd()` {#fs.cwd}
 
 ```lua
-local ok, err = fs.write(url, "hello world")
+local current_working_directory = fs.cwd()
 ```
 
-Write data to the specified file:
+Get the [Url](/docs/plugins/types#shared.url) of the current working directory.
+Most of the time, it is very unlikely that you will need this API, as the
+current working directory obtained is likely to be out of date when the user
+takes an action.
+You should be using [`cx.active.current.cwd`](/docs/plugins/types#app-data.folder-folder) instead.
+This function just fills the gap as Lua lacks a [`getcwd`](https://man7.org/linux/man-pages/man3/getcwd.3.html) API.
+It is useful if you just need a valid directory as the current working directory
+of a process to start some work that doesn't depend on the current working directory,
+like in the example [here](https://github.com/sxyazi/yazi/blob/d746ae8338112ff27b56bedf4da9e8764fb5f7da/yazi-plugin/preset/plugins/zoxide.lua#L70).
 
-- `url` - Required, the [Url](/docs/plugins/types#shared.url) of the file
-- `data` - Required, the data to be written, which is a string
+Returns `(url, err)`
 
-Returns `(ok, err)`:
-
-- `ok` - Whether the operation is successful, which is a boolean
-- `err` - The error code if the operation is failed, which is an integer if any
-
-### `remove(type, url)` {#fs.remove}
-
-```lua
-local ok, err = fs.remove("file", Url("/tmp/test.txt"))
-```
-
-Remove the specified file(s) from the filesystem:
-
-- `type` - Required, the type of removal, which can be:
-  - `"file"` - Removes a file from the filesystem.
-  - `"dir"` - Removes an existing, empty directory.
-  - `"dir_all"` - Removes a directory at this url, after removing all its contents. Use carefully!
-  - `"dir_clean"` - Remove all empty directories under it, and if the directory itself is empty afterward, remove it as well.
-- `url` - Required, the [Url](/docs/plugins/types#shared.url) of the target.
-
-Returns `(ok, err)`:
-
-- `ok` - Whether the operation is successful, which is a boolean
-- `err` - The error code if the operation is failed, which is an integer if any
-
-### `read_dir(url, options)` {#fs.read_dir}
-
-```lua
-local files, err = fs.read_dir("url", { limit = 10 })
-```
-
-Reads the contents of a directory:
-
-- `url` - Required, the [Url](/docs/plugins/types#shared.url) of the directory.
-- `options` - Optional, a table with the following options:
-  - `glob` - A glob pattern to filter files out if provided.
-  - `limit` - The maximum number of files to read, which is an integer, defaults to unlimited.
-  - `resolve` - Whether to resolve symbolic links, defaults to `false`.
-
-Returns `(files, err)`:
-
-- `files` - A table of [File](/docs/plugins/types#shared.file) if successful; otherwise, `nil`.
-- `err` - The error code if the operation is failed, which is an integer if any.
+- `url`: The [Url](/docs/plugins/types#shared.url) of the current working directory if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ### `cha(url, follow)` {#fs.cha}
 
@@ -472,13 +455,103 @@ local cha, err = fs.cha(url)
 
 Get the [Cha](/docs/plugins/types#shared.cha) of the specified file:
 
-- `url` - Required, the [Url](/docs/plugins/types#shared.url) of the file
-- `follow` - Optional, whether to follow the symbolic link, which is a boolean
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the file.
+- `follow`: Optional, whether to follow the symbolic link, which is a boolean.
 
 Returns `(cha, err)`:
 
-- `cha` - The [Cha](/docs/plugins/types#shared.cha) of the file if successful; otherwise, `nil`
-- `err` - The error code if the operation is failed, which is an integer if any
+- `cha`: The [Cha](/docs/plugins/types#shared.cha) of the file if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `write(url, data)` {#fs.write}
+
+```lua
+local ok, err = fs.write(url, "hello world")
+```
+
+Write data to the specified file:
+
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the file.
+- `data`: Required, the data to be written, which is a string.
+
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation is successful, which is a boolean.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `create(type, url)` {#fs.create}
+
+```lua
+local ok, err = fs.create("dir_all", Url("/tmp/test/nest/nested"))
+```
+
+Create the specified file(s) in the filesystem.
+
+- `type`: Required, the type of creation, which can be:
+  - `"dir"`: Create an empty directory.
+  - `"dir_all"`: Recursive creates all the directories needed for the given path to exist.
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the target.
+
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation is successful, which is a boolean.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `remove(type, url)` {#fs.remove}
+
+```lua
+local ok, err = fs.remove("file", Url("/tmp/test.txt"))
+```
+
+Remove the specified file(s) from the filesystem:
+
+- `type`: Required, the type of removal, which can be:
+  - `"file"`: Removes a file from the filesystem.
+  - `"dir"`: Removes an existing, empty directory.
+  - `"dir_all"`: Removes a directory at this url, after removing all its contents. Use carefully!
+  - `"dir_clean"`: Remove all empty directories under it, and if the directory itself is empty afterward, remove it as well.
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the target.
+
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation is successful, which is a boolean.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `read_dir(url, options)` {#fs.read_dir}
+
+```lua
+local files, err = fs.read_dir("url", { limit = 10 })
+```
+
+Reads the contents of a directory:
+
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the directory.
+- `options`: Optional, a table with the following options:
+  - `glob`: A glob pattern to filter files out if provided.
+  - `limit`: The maximum number of files to read, which is an integer, defaults to unlimited.
+  - `resolve`: Whether to resolve symbolic links, defaults to `false`.
+
+Returns `(files, err)`:
+
+- `files`: A table of [File](/docs/plugins/types#shared.file) if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `unique_name(url)`
+
+```lua
+local url, err = fs.unique_name(Url("/tmp/test.txt"))
+```
+
+Create a unique name for the given [Url](/docs/plugins/types#shared.url) if it already exists.
+The function usually just appends `_n` to the back of the file name in the given [Url](/docs/plugins/types#shared.url), where `n` is an integer.
+Otherwise, it just returns the given [Url](/docs/plugins/types#shared.url).
+
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the path to get a unique name.
+
+Returns `(url, err)`
+
+- `url`: The unique [Url](/docs/plugins/types#shared.url) of the given path if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ## Command
 
@@ -503,7 +576,7 @@ local cmd = Command("ls"):arg("-a"):arg("-l")
 
 Append an argument to the command:
 
-- `arg` - Required, the argument to be appended, which is a string
+- `arg`: Required, the argument to be appended, which is a string.
 
 Returns `self`.
 
@@ -515,7 +588,7 @@ local cmd = Command("ls"):args({ "-a", "-l" }):args({ "-h" })
 
 Append multiple arguments to the command:
 
-- `args` - Required, the arguments to be appended, which is a table of strings
+- `args`: Required, the arguments to be appended, which is a table of strings.
 
 Returns `self`.
 
@@ -527,7 +600,7 @@ local cmd = Command("ls"):cwd("/root")
 
 Set the current working directory of the command:
 
-- `dir` - Required, the directory of the command, which is a string
+- `dir`: Required, the directory of the command, which is a string.
 
 Returns `self`.
 
@@ -539,8 +612,8 @@ local cmd = Command("ls"):env("PATH", "/bin"):env("HOME", "/home")
 
 Append an environment variable to the command:
 
-- `key` - Required, the key of the environment variable, which is a string
-- `value` - Required, the value of the environment variable, which is a string
+- `key`: Required, the key of the environment variable, which is a string.
+- `value`: Required, the value of the environment variable, which is a string.
 
 Returns `self`.
 
@@ -552,10 +625,10 @@ local cmd = Command("ls"):stdin(Command.PIPED)
 
 Set the stdin of the command:
 
-- `cfg` - Required, the configuration of the stdin, accepts the following values:
-  - `Command.PIPED` - Pipe the stdin
-  - `Command.NULL` - Discard the stdin
-  - `Command.INHERIT` - Inherit the stdin
+- `cfg`: Required, the configuration of the stdin, accepts the following values:
+  - `Command.PIPED`: Pipe the stdin.
+  - `Command.NULL`: Discard the stdin.
+  - `Command.INHERIT`: Inherit the stdin.
 
 If not set, the stdin will be null. Returns `self`.
 
@@ -567,10 +640,10 @@ local cmd = Command("ls"):stdout(Command.PIPED)
 
 Set the stdout of the command:
 
-- `cfg` - Required, the configuration of the stdout, accepts the following values:
-  - `Command.PIPED` - Pipe the stdout
-  - `Command.NULL` - Discard the stdout
-  - `Command.INHERIT` - Inherit the stdout
+- `cfg`: Required, the configuration of the stdout, accepts the following values:
+  - `Command.PIPED`: Pipe the stdout.
+  - `Command.NULL`: Discard the stdout.
+  - `Command.INHERIT`: Inherit the stdout.
 
 If not set, the stdout will be null. Returns `self`.
 
@@ -582,10 +655,10 @@ local cmd = Command("ls"):stderr(Command.PIPED)
 
 Set the stderr of the command:
 
-- `cfg` - Required, the configuration of the stderr, accepts the following values:
-  - `Command.PIPED` - Pipe the stderr
-  - `Command.NULL` - Discard the stderr
-  - `Command.INHERIT` - Inherit the stderr
+- `cfg`: Required, the configuration of the stderr, accepts the following values:
+  - `Command.PIPED`: Pipe the stderr.
+  - `Command.NULL`: Discard the stderr.
+  - `Command.INHERIT`: Inherit the stderr.
 
 If not set, the stderr will be null. Returns `self`.
 
@@ -597,8 +670,8 @@ local child, err = Command("ls"):spawn()
 
 Spawn the command, returns `(child, err)`:
 
-- `child` - The [Child](#child) of the command if successful; otherwise, `nil`
-- `err` - The error code if the operation is failed, which is an integer if any
+- `child`: The [Child](#child) of the command if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ### `output()` {#Command.output}
 
@@ -608,8 +681,8 @@ local output, err = Command("ls"):output()
 
 Spawn the command and wait for it to finish, returns `(output, err)`:
 
-- `output` - The [Output](#output) of the command if successful; otherwise, `nil`
-- `err` - The error code if the operation is failed, which is an integer if any
+- `output`: The [Output](#output) of the command if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ### `status()` {#Command.status}
 
@@ -619,8 +692,8 @@ local status, err = Command("ls"):status()
 
 Executes the command as a child process, waiting for it to finish and collecting its exit status. Returns `(status, err)`:
 
-- `status` - The [Status](#status) of the child process if successful; otherwise, `nil`
-- `err` - The error code if the operation is failed, which is an integer if any
+- `status`: The [Status](#status) of the child process if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ## Child
 
@@ -638,9 +711,9 @@ Let's say "available data source" refers to `stdout` or `stderr` that has been s
 
 `read()` reads data from the available data source alternately, and the `event` indicates the source of the data:
 
-- The data comes from stdout if event is 0
-- The data comes from stderr if event is 1
-- There's no data to read from both stdout and stderr, if event is 2
+- The data comes from stdout if event is 0.
+- The data comes from stderr if event is 1.
+- There's no data to read from both stdout and stderr, if event is 2.
 
 ### `read_line()` {#Child.read_line}
 
@@ -658,11 +731,11 @@ local line, event = child:read_line_with { timeout = 500 }
 
 Similar to [`read_line()`](#Child.read_line), but it accepts a table of options:
 
-- `timeout` - Required, timeout in milliseconds, which is an integer
+- `timeout`: Required, timeout in milliseconds, which is an integer
 
 And includes the following additional events:
 
-- Timeout if event is 3
+- Timeout if event is 3.
 
 ### `wait()` {#Child.wait}
 
@@ -672,8 +745,8 @@ local status, err = child:wait()
 
 Wait for the child process to finish, returns `(status, err)`:
 
-- `status` - The [Status](#status) of the child process if successful; otherwise, `nil`
-- `err` - The error code if the operation is failed, which is an integer if any
+- `status`: The [Status](#status) of the child process if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ### `wait_with_output()` {#Child.wait_with_output}
 
@@ -683,8 +756,8 @@ local output, err = child:wait_with_output()
 
 Wait for the child process to finish and get the output, returns `(output, err)`:
 
-- `output` - The [Output](#output) of the child process if successful; otherwise, `nil`
-- `err` - The error code if the operation is failed, which is an integer if any
+- `output`: The [Output](#output) of the child process if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ### `start_kill()` {#Child.start_kill}
 
@@ -694,8 +767,8 @@ local ok, err = child:start_kill()
 
 Send a SIGTERM signal to the child process, returns `(ok, err)`:
 
-- `ok` - Whether the operation is successful, which is a boolean
-- `err` - The error code if the operation is failed, which is an integer if any
+- `ok`: Whether the operation is successful, which is a boolean.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 ### `take_stdin()` {#Child.take_stdin}
 
@@ -741,15 +814,15 @@ local ok, err = child:write_all(src)
 
 Writes all bytes from the string `src` to the stdin of the child process, returns `(ok, err)`:
 
-- `ok` - Whether the operation is successful, which is a boolean
-- `err` - The error code if the operation is failed, which is an integer if any
+- `ok`: Whether the operation is successful, which is a boolean.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 Please ensure that the child's stdin is available when calling this method, specifically:
 
-1. [`stdin(Command.PIPED)`](/docs/plugins/utils#Command.stdin) is set
-2. [`take_stdin()`](/docs/plugins/utils#Child.take_stdin) has never been called
+1. [`stdin(Command.PIPED)`](/docs/plugins/utils#Command.stdin) is set.
+2. [`take_stdin()`](/docs/plugins/utils#Child.take_stdin) has never been called.
 
-otherwise, an error will be thrown.
+Otherwise, an error will be thrown.
 
 ### `flush()` {#Child.flush}
 
@@ -759,23 +832,23 @@ local ok, err = child:flush()
 
 Flushes any buffered data to the stdin of the child process, returns `(ok, err)`:
 
-- `ok` - Whether the operation is successful, which is a boolean
-- `err` - The error code if the operation is failed, which is an integer if any
+- `ok`: Whether the operation is successful, which is a boolean.
+- `err`: The error code if the operation is failed, which is an integer if any.
 
 Please ensure that the child's stdin is available when calling this method, specifically:
 
-1. [`stdin(Command.PIPED)`](/docs/plugins/utils#Command.stdin) is set
-2. [`take_stdin()`](/docs/plugins/utils#Child.take_stdin) has never been called
+1. [`stdin(Command.PIPED)`](/docs/plugins/utils#Command.stdin) is set.
+2. [`take_stdin()`](/docs/plugins/utils#Child.take_stdin) has never been called.
 
-otherwise, an error will be thrown.
+Otherwise, an error will be thrown.
 
 ## Output
 
 Properties:
 
-- `status`: The [Status](#status) of the child process
-- `stdout`: The stdout of the child process, which is a string
-- `stderr`: The stderr of the child process, which is a string
+- `status`: The [Status](#status) of the child process.
+- `stdout`: The stdout of the child process, which is a string.
+- `stderr`: The stderr of the child process, which is a string.
 
 ## Status
 
@@ -784,4 +857,4 @@ This object represents the exit status of a child process, and it is created by 
 Properties:
 
 - `success`: whether the child process exited successfully, which is a boolean.
-- `code`: the exit code of the child process, which is an integer if any
+- `code`: the exit code of the child process, which is an integer if any.

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -282,22 +282,6 @@ Truncate the text to the specified length and return it:
   - `max`: Required, the maximum length of the text, which is an integer.
   - `rtl`: Optional, whether the text is right-to-left, which is a boolean.
 
-### `clipboard(text)` {#ya.clipboard}
-
-Get or set the content of the system clipboard.
-
-- `text`: Optional, value to be set, which is a string. If not provided, the content of the clipboard will be returned.
-
-```lua
--- Get contents from the clipboard
-local content = ya.clipboard()
-
--- Set contents to the clipboard
-ya.clipboard("new content")
-```
-
-This function is only available in the async context.
-
 ### `time()` {#ya.time}
 
 Returns the current timestamp, which is a float, the integer part represents the seconds, and the decimal part represents the milliseconds.
@@ -345,6 +329,22 @@ This function is only available on Unix-like systems.
 ### `host_name()` {#ya.host_name}
 
 Only available on Unix-like systems. Returns the hostname of the current machine, which is a string if successful; otherwise, `nil`.
+
+### `clipboard(text)` {#ya.clipboard}
+
+Get or set the content of the system clipboard.
+
+- `text`: Optional, value to be set, which is a string. If not provided, the content of the clipboard will be returned.
+
+```lua
+-- Get contents from the clipboard
+local content = ya.clipboard()
+
+-- Set contents to the clipboard
+ya.clipboard("new content")
+```
+
+This function is only available in the async context.
 
 ## ps {#ps}
 
@@ -426,43 +426,6 @@ Unsubscribe from remote messages of this `kind`:
 
 The following functions can only be used within an async context.
 
-### `cwd()` {#fs.cwd}
-
-```lua
-local current_working_directory = fs.cwd()
-```
-
-Get the [Url](/docs/plugins/types#shared.url) of the current working directory.
-Most of the time, it is very unlikely that you will need this API, as the
-current working directory obtained is likely to be out of date when the user
-takes an action.
-You should be using [`cx.active.current.cwd`](/docs/plugins/types#app-data.folder-folder) instead.
-This function just fills the gap as Lua lacks a [`getcwd`](https://man7.org/linux/man-pages/man3/getcwd.3.html) API.
-It is useful if you just need a valid directory as the current working directory
-of a process to start some work that doesn't depend on the current working directory,
-like in the example [here](https://github.com/sxyazi/yazi/blob/d746ae8338112ff27b56bedf4da9e8764fb5f7da/yazi-plugin/preset/plugins/zoxide.lua#L70).
-
-Returns `(url, err)`
-
-- `url`: The [Url](/docs/plugins/types#shared.url) of the current working directory if successful; otherwise, `nil`.
-- `err`: The error code if the operation is failed, which is an integer if any.
-
-### `cha(url, follow)` {#fs.cha}
-
-```lua
-local cha, err = fs.cha(url)
-```
-
-Get the [Cha](/docs/plugins/types#shared.cha) of the specified file:
-
-- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the file.
-- `follow`: Optional, whether to follow the symbolic link, which is a boolean.
-
-Returns `(cha, err)`:
-
-- `cha`: The [Cha](/docs/plugins/types#shared.cha) of the file if successful; otherwise, `nil`.
-- `err`: The error code if the operation is failed, which is an integer if any.
-
 ### `write(url, data)` {#fs.write}
 
 ```lua
@@ -473,24 +436,6 @@ Write data to the specified file:
 
 - `url`: Required, the [Url](/docs/plugins/types#shared.url) of the file.
 - `data`: Required, the data to be written, which is a string.
-
-Returns `(ok, err)`:
-
-- `ok`: Whether the operation is successful, which is a boolean.
-- `err`: The error code if the operation is failed, which is an integer if any.
-
-### `create(type, url)` {#fs.create}
-
-```lua
-local ok, err = fs.create("dir_all", Url("/tmp/test/nest/nested"))
-```
-
-Create the specified file(s) in the filesystem.
-
-- `type`: Required, the type of creation, which can be:
-  - `"dir"`: Create an empty directory.
-  - `"dir_all"`: Recursive creates all the directories needed for the given path to exist.
-- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the target.
 
 Returns `(ok, err)`:
 
@@ -534,6 +479,61 @@ Reads the contents of a directory:
 Returns `(files, err)`:
 
 - `files`: A table of [File](/docs/plugins/types#shared.file) if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `cha(url, follow)` {#fs.cha}
+
+```lua
+local cha, err = fs.cha(url)
+```
+
+Get the [Cha](/docs/plugins/types#shared.cha) of the specified file:
+
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the file.
+- `follow`: Optional, whether to follow the symbolic link, which is a boolean.
+
+Returns `(cha, err)`:
+
+- `cha`: The [Cha](/docs/plugins/types#shared.cha) of the file if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `cwd()` {#fs.cwd}
+
+```lua
+local current_working_directory = fs.cwd()
+```
+
+Get the [Url](/docs/plugins/types#shared.url) of the current working directory.
+Most of the time, it is very unlikely that you will need this API, as the
+current working directory obtained is likely to be out of date when the user
+takes an action.
+You should be using [`cx.active.current.cwd`](/docs/plugins/types#app-data.folder-folder) instead.
+This function just fills the gap as Lua lacks a [`getcwd`](https://man7.org/linux/man-pages/man3/getcwd.3.html) API.
+It is useful if you just need a valid directory as the current working directory
+of a process to start some work that doesn't depend on the current working directory,
+like in the example [here](https://github.com/sxyazi/yazi/blob/d746ae8338112ff27b56bedf4da9e8764fb5f7da/yazi-plugin/preset/plugins/zoxide.lua#L70).
+
+Returns `(url, err)`
+
+- `url`: The [Url](/docs/plugins/types#shared.url) of the current working directory if successful; otherwise, `nil`.
+- `err`: The error code if the operation is failed, which is an integer if any.
+
+### `create(type, url)` {#fs.create}
+
+```lua
+local ok, err = fs.create("dir_all", Url("/tmp/test/nest/nested"))
+```
+
+Create the specified file(s) in the filesystem.
+
+- `type`: Required, the type of creation, which can be:
+  - `"dir"`: Create an empty directory.
+  - `"dir_all"`: Recursive creates all the directories needed for the given path to exist.
+- `url`: Required, the [Url](/docs/plugins/types#shared.url) of the target.
+
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation is successful, which is a boolean.
 - `err`: The error code if the operation is failed, which is an integer if any.
 
 ### `unique_name(url)`

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -401,7 +401,8 @@ Subscribe to local messages of `kind` and call the `callback` handler for it:
 
 - `kind`: Required, the kind of the message, which is a string.
 - `callback`: Required, the callback function, with a single parameter `body` containing the content of the message.
-  It runs in a sync context, so you can access app data via `cx` for the content of interest.
+
+It runs in a sync context, so you can access app data via `cx` for the content of interest.
 
 Note: No time-consuming operations should be done in the callback, and the same `kind` from the same plugin can only be subscribed once, re-subscribing (`sub()`) before unsubscribing (`unsub()`) will throw an error.
 
@@ -507,23 +508,23 @@ Returns `(cha, err)`:
 ### `cwd()` {#fs.cwd}
 
 ```lua
-local current_working_directory = fs.cwd()
+local url, err = fs.cwd()
 ```
 
-Get the [Url](/docs/plugins/types#shared.url) of the current working directory.
-Most of the time, it is very unlikely that you will need this API, as the
-current working directory obtained is likely to be out of date when the user
-takes an action.
-You should be using [`cx.active.current.cwd`](/docs/plugins/types#app-data.folder-folder) instead.
-This function just fills the gap as Lua lacks a [`getcwd`](https://man7.org/linux/man-pages/man3/getcwd.3.html) API.
-It is useful if you just need a valid directory as the current working directory
-of a process to start some work that doesn't depend on the current working directory,
-like in the example [here](https://github.com/sxyazi/yazi/blob/d746ae8338112ff27b56bedf4da9e8764fb5f7da/yazi-plugin/preset/plugins/zoxide.lua#L70).
+This function was added to compensate for the lack of a `getcwd` in Lua; it is used to retrieve the directory of the last `chdir` call.
 
-Returns `(url, err)`
+You probably will never need it, and more likely, you'll need `cx.active.current.cwd`, which is the current directory where the user is working.
+
+Specifically, when the user changes the directory, `cx.active.current.cwd` gets updated immediately, while synchronizing this update with the filesystem via `chdir` involves I/O operations, such as checking if the directory is valid.
+
+So, there may be some delay, which is particularly noticeable on slow devices. For example, when an HDD wakes up from sleep, it typically takes 3~4 seconds.
+
+Returns `(url, err)`:
 
 - `url`: The [Url](/docs/plugins/types#shared.url) of the current working directory if successful; otherwise, `nil`.
 - `err`: The error code if the operation is failed, which is an integer if any.
+
+It is useful if you just need a valid directory as the CWD of a process to start some work that doesn't depend on the CWD.
 
 ### `create(type, url)` {#fs.create}
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -38,11 +38,14 @@ If the file is not allowed to be cached, such as it's ignored in the user config
 
 ### `render()` {#ya.render}
 
-```lua
-ya.render()
-```
+Re-render the UI, can only be used in the sync context, for example:
 
-Re-render Yazi's UI.
+```lua
+local update_state = ya.sync(function(self, new_state)
+	self.state = new_state
+	ya.render()
+end)
+```
 
 ### `manager_emit(cmd, args)` {#ya.manager_emit}
 
@@ -256,12 +259,16 @@ Returns a string describing the specific operating system in use. Some possible 
 ### `hash(str)` {#ya.hash}
 
 ```lua
-ya.hash("test.txt")
+ya.hash("Hello, World!")
 ```
 
-Returns the MD5 hash of a given string, which is a `string`.
+Returns the hash of a given string:
 
-- `str`: Required, the string to calculate the MD5 hash for.
+- `str`: Required, the string to calculate the hash for.
+
+It is designed to work with algorithm-independent tasks, such as generating file cache names.
+
+The current implementation uses MD5, but it will be replaced with a faster hash algorithm, like [xxHash](https://github.com/Cyan4973/xxHash), in the future. So, don't rely on this implementation detail.
 
 ### `quote(str)` {#ya.quote}
 
@@ -527,14 +534,14 @@ local ok, err = fs.create("dir_all", Url("/tmp/test/nest/nested"))
 Create the specified file(s) in the filesystem.
 
 - `type`: Required, the type of creation, which can be:
-  - `"dir"`: Create an empty directory.
-  - `"dir_all"`: Recursive creates all the directories needed for the given path to exist.
+  - `"dir"`: Creates a new, empty directory.
+  - `"dir_all"`: Recursively create a directory and all of its parents if they are missing.
 - `url`: Required, the [Url](/docs/plugins/types#shared.url) of the target.
 
 Returns `(ok, err)`:
 
 - `ok`: Whether the operation is successful, which is a boolean.
-- `err`: The error code if the operation is failed, which is an integer if any.
+- `err`: The error if the operation is failed, which is an [Error](/docs/plugins/types#shared.error).
 
 ### `unique_name(url)`
 
@@ -542,16 +549,16 @@ Returns `(ok, err)`:
 local url, err = fs.unique_name(Url("/tmp/test.txt"))
 ```
 
-Create a unique name for the given [Url](/docs/plugins/types#shared.url) if it already exists.
-The function usually just appends `_n` to the back of the file name in the given [Url](/docs/plugins/types#shared.url), where `n` is an integer.
-Otherwise, it just returns the given [Url](/docs/plugins/types#shared.url).
+Get a unique name from the given [Url](/docs/plugins/types#shared.url) to ensure it's unique in the filesystem:
 
 - `url`: Required, the [Url](/docs/plugins/types#shared.url) of the path to get a unique name.
 
-Returns `(url, err)`
+Returns `(url, err)`:
 
 - `url`: The unique [Url](/docs/plugins/types#shared.url) of the given path if successful; otherwise, `nil`.
-- `err`: The error code if the operation is failed, which is an integer if any.
+- `err`: The error if the operation is failed, which is an [Error](/docs/plugins/types#shared.error).
+
+If the file already exists, the function will append `_n` to the filename, where `n` is a number, and keep incrementing it until it finds the first available name.
 
 ## Command
 


### PR DESCRIPTION
I documented the APIs that I have used and know about, but there are many I have no idea how to use, so I didn't document those.

The APIs I didn't document are:
- `redraw_with`
- `app_emit`
- `input_emit`
- `image_info`
- `json_encode`
- `json_decode`
- `spot_table`
- `spot_widgets`

I also reordered the APIs to match the order in the source files, and standardised the style, by adding full stops after every list item and using the colon instead of the dash for the description of the arguments and return values.