### PR TITLE
fix: make powershell y command work with non-english characters

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -91,8 +91,7 @@ function y {
     yazi --cwd-file="$tmp"
     $cwd = Get-Content -Path $tmp -Encoding UTF8
     if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
-        $cwd = [System.IO.Path]::GetFullPath($cwd)
-        Set-Location -LiteralPath $cwd
+        Set-Location -LiteralPath [System.IO.Path]::GetFullPath($cwd)
     }
     Remove-Item -Path $tmp
 }

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -88,7 +88,7 @@ edit:add-var y~ {|@argv|
 ```powershell
 function y {
     $tmp = [System.IO.Path]::GetTempFileName()
-    yazi --cwd-file="$tmp"
+    yazi $args --cwd-file="$tmp"
     $cwd = Get-Content -Path $tmp -Encoding UTF8
     if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
         Set-Location -LiteralPath [System.IO.Path]::GetFullPath($cwd)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -88,9 +88,10 @@ edit:add-var y~ {|@argv|
 ```powershell
 function y {
     $tmp = [System.IO.Path]::GetTempFileName()
-    yazi $args --cwd-file="$tmp"
-    $cwd = Get-Content -Path $tmp
+    yazi --cwd-file="$tmp"
+    $cwd = Get-Content -Path $tmp -Encoding UTF8
     if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
+        $cwd = [System.IO.Path]::GetFullPath($cwd)
         Set-Location -LiteralPath $cwd
     }
     Remove-Item -Path $tmp


### PR DESCRIPTION
## Description
Makes the following changes to the `y` powershell command:
- Adds UTF8 encoding flag for handling non english characters
- Adds `GetFullPath`, to convert possible `/` to `\`