### PR TITLE
docs: fix shell wrapper for PowerShell

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -91,7 +91,7 @@ function y {
     yazi $args --cwd-file="$tmp"
     $cwd = Get-Content -Path $tmp -Encoding UTF8
     if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
-        Set-Location -LiteralPath [System.IO.Path]::GetFullPath($cwd)
+        Set-Location -LiteralPath ([System.IO.Path]::GetFullPath($cwd))
     }
     Remove-Item -Path $tmp
 }


### PR DESCRIPTION
This makes sure that `GetFullPath` gets evaluated before passing its value to `Set-Location`. This prevents `Set-Location` from raising an error "A positional parameter cannot be found that accepts argument 'C:\path\to\dir'".

******

I received this error on both PowerShell and Windows PowerShell ([yes, there's a difference :sweat_smile:](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.4)). Additionally I double-checked if there was any difference between PowerShell on Linux and on Windows, just to see if this was somehow OS-specific. This changed resolved the issue for both Windows PowerShell and PowerShell.

Related: https://github.com/yazi-rs/yazi-rs.github.io/pull/191