### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,13 @@
 {
     "name": "Node.js",
-    "image": "mcr.microsoft.com/devcontainers/typescript-node"
+    "image": "mcr.microsoft.com/devcontainers/typescript-node",
+    "postCreateCommand": "pnpm install",
+    "postAttachCommand": "pnpm start",
+    "forwardPorts": [3000],
+    "portsAttributes": {
+        "3000": {
+            "label": "Site",
+            "onAutoForward": "notify"
+        }
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "name": "Node.js",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node"
+}


### PR DESCRIPTION
I was considering making some contributions to this repository, and having a devcontainer config can really help out. My personal use case is using a [GitHub Codespace](https://github.com/features/codespaces) (cloud-hosted development environment) and using VS Code on the Web, but this also supports other use cases, like a local docker container for development. This:
* Allows users to use a pre-configured development environment in the cloud, which is helpful when the contributor is away from their main device.
* Helps contributors avoid cluttering their environment by installing all required files to a temporary container.
* Lets maintainers preview changes without needing to clone a fork to their own device.

This configuration will:
* Create a development container with Node.js and TypeScript installed (and a few other utilities, like `pnpm`).
* Install dependencies the first time the container is created.
* Start the site every time a contributor accesses their container (this will be accessible at a unique URL generated by GitHub).

There might be some other settings you'd like to add, such as:
* Install required or highly recommended VS Code extensions (e.g. Prettier or spell checker).
* Set VS Code settings (e.g. `"editor.formatOnSave" = true`).
* Using a `Dockerfile` if you want to further customize the image used for the devcontainer.

You can test it out by accessing my fork and creating a codespace from the "Code" dropdown.