### PR TITLE
docs: add `y` function for Xonsh

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -119,6 +119,22 @@ del "%tmpfile%"
 ```
 
   </TabItem>
+  <TabItem value="xonsh" label="Xonsh">
+
+```xonsh
+def y():
+    tmp = $(mktemp -t "yazi-cwd.XXXXXX")
+    $[yazi @(f"--cwd-file={tmp}")]
+    with open(tmp) as f:
+        cwd = f.read().strip()
+    if cwd != $PWD:
+        cd @(cwd)
+    rm -f -- @(tmp)
+
+aliases["y"] = y
+```
+
+  </TabItem>
 </Tabs>
 
 To use it, copy the function into the configuration file of your respective shell.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -122,16 +122,17 @@ del "%tmpfile%"
   <TabItem value="xonsh" label="Xonsh">
 
 ```xonsh
-def y():
+def _y(args):
     tmp = $(mktemp -t "yazi-cwd.XXXXXX")
-    $[yazi @(f"--cwd-file={tmp}")]
+    args.append(f"--cwd-file={tmp}")
+    $[yazi @(args)]
     with open(tmp) as f:
         cwd = f.read().strip()
     if cwd != $PWD:
         cd @(cwd)
     rm -f -- @(tmp)
 
-aliases["y"] = y
+aliases["y"] = _y
 ```
 
   </TabItem>


### PR DESCRIPTION
This PR a [Xonsh](https://xon.sh/) version for the `y` command to the docs. Works smoothly on my machine. WDYT?