### PR TITLE
docs: update Windows Terminal to stable

### DIFF
--- a/docs/image-preview.md
+++ b/docs/image-preview.md
@@ -17,7 +17,7 @@ This is by no means a simple task, to reduce maintenance costs, we only guarante
 | [Konsole](https://invent.kde.org/utilities/konsole)                                                           | [Kitty old protocol][kgp-old]          | ✅ Built-in                                           |
 | [foot](https://codeberg.org/dnkl/foot)                                                                        | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
 | [Ghostty](https://github.com/ghostty-org/ghostty)                                                             | [Kitty unicode placeholders][kgp]      | ✅ Built-in                                           |
-| [Windows Terminal Preview](https://github.com/microsoft/terminal/releases/tag/v1.22.2702.0) (>= v1.22.2702.0) | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
+| [Windows Terminal](https://github.com/microsoft/terminal) (>= v1.22.10352.0)                                  | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
 | [st with Sixel patch](https://github.com/bakkeby/st-flexipatch)                                               | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
 | [Tabby](https://github.com/Eugeny/tabby)                                                                      | [Inline images protocol][iip]          | ✅ Built-in                                           |
 | [VSCode](https://github.com/microsoft/vscode)                                                                 | [Inline images protocol][iip]          | ✅ Built-in                                           |


### PR DESCRIPTION
Sixel support in Windows Terminal is now stable as of https://github.com/microsoft/terminal/releases/tag/v1.22.10352.0 