### PR TITLE
Add Bobcat to the image-preview capable VTEs list (on Windows)

### DIFF
--- a/docs/image-preview.md
+++ b/docs/image-preview.md
@@ -93,7 +93,7 @@ Currently, only the following 3 terminals support displaying images on Windows:
 
 - WezTerm
 - [Windows Terminal Preview v1.22.2702.0](https://github.com/microsoft/terminal/releases/tag/v1.22.2702.0)
-- [Bobcat v0.9.0](https://github.com/ismail-yilmaz/Bobcat/releases/tag/0.9.0) (requires the bundled `OpenConsole.exe`)
+- [Bobcat v0.9.0](https://github.com/ismail-yilmaz/Bobcat/releases/tag/0.9.0)
 
 ## Windows with WSL users {#wsl}
 

--- a/docs/image-preview.md
+++ b/docs/image-preview.md
@@ -89,10 +89,11 @@ NVIM=1 NVIM_LOG_FILE=1 yazi
 
 ## Windows users {#windows}
 
-Currently, only the following 2 terminals support displaying images on Windows:
+Currently, only the following 3 terminals support displaying images on Windows:
 
 - WezTerm
 - [Windows Terminal Preview v1.22.2702.0](https://github.com/microsoft/terminal/releases/tag/v1.22.2702.0)
+- Bobcat (version >= 0.9.r242, requires the preview version of `conpty.dll` + `OpenConsole.exe`)
 
 ## Windows with WSL users {#wsl}
 

--- a/docs/image-preview.md
+++ b/docs/image-preview.md
@@ -93,7 +93,7 @@ Currently, only the following 3 terminals support displaying images on Windows:
 
 - WezTerm
 - [Windows Terminal Preview v1.22.2702.0](https://github.com/microsoft/terminal/releases/tag/v1.22.2702.0)
-- Bobcat (version >= 0.9.r242, requires the preview version of `conpty.dll` + `OpenConsole.exe`)
+- [Bobcat v0.9.0](https://github.com/ismail-yilmaz/Bobcat/releases/tag/0.9.0) (requires the bundled `OpenConsole.exe`)
 
 ## Windows with WSL users {#wsl}
 


### PR DESCRIPTION
This PR adds Bobcat to the list of VTEs that can display images with yazi on Windows.

Requirements:  Bobcat's latest version (v0.9.r242), and the preview version of  `conpty.dll` + `OpenConsole.exe`.

A visual:

![bobcat-yazi](https://github.com/user-attachments/assets/04c98ad9-22ac-4d57-8d13-464ee23a00ee)
