### PR TITLE
docs: update the levels for ya.notify

### DIFF
--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -164,17 +164,17 @@ This function is only available in the async context.
 Send a foreground notification to the user:
 
 - `opts`: Required, the options of the notification, which is a table:
-  - `title`: Required, the title of the notification, which is a string.
+  - `title`: Required, the notification's title, which is a string.
   - `content`: Required, the content of the notification, which is a string.
-  - `timeout`: Required, the timeout of the notification, which is an non-negative float in seconds.
-  - `level`: Optional, the level of the notification, which is a string accepts `"info"`, `"warn"`, and `"error"`. Default is `"info"`.
+  - `timeout`: Required, the timeout of the notification, which is a non-negative float in seconds.
+  - `level`: Optional, the level of the notification, which is a string that accepts `"Info"`, `"Warn"`, and `"Error"`. The default is `"Info"`.
 
 ```lua
 ya.notify {
 	title = "Hello, World!",
 	content = "This is a notification from Lua!",
 	timeout = 6.5,
-	-- level = "info",
+	-- level = "Info",
 }
 ```
 


### PR DESCRIPTION
I don't know if this is intended, but the options for the notification level have changed from lowercase to titlecase.

The error I get when using the lowercase version is shown below:

```
Failed to run the plugin:
unknown variant `warn`, expected one of `Info`, `Warn`, `Error`
stack traceback:
        [C]: in field 'notify'
        [string "augment-command"]:576: in upvalue 'show_warning'
        [string "augment-command"]:3020: in upvalue 'fix_shell_command'
        [string "augment-command"]:3053: in upvalue 'handle_shell'
        [string "augment-command"]:3562: in local 'command_func'
        [string "augment-command"]:3611: in upvalue 'run_command_func'
        [string "augment-command"]:3651: in function <[string "augment-command"]:3629>
```