### PR TITLE
Improve confirm-quit plugin in tips.md

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -374,7 +374,7 @@ local function entry()
 	end
 
 	local yes = ya.confirm {
-		pos = { "center", w = 60, h = 10 },
+		pos = { "center", w = 62, h = 10 },
 		title = "Quit?",
 		content = "There are multiple tabs open. Are you sure you want to quit?",
 	}

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -374,9 +374,9 @@ local function entry()
 	end
 
 	local yes = ya.confirm {
-		pos = { "center", w = 62, h = 10 },
+		pos = { "center", w = 60, h = 10 },
 		title = "Quit?",
-		content = "There are multiple tabs open. Are you sure you want to quit?",
+		content = ui.Text("There are multiple tabs open. Are you sure you want to quit?"):wrap(ui.Text.WRAP),
 	}
 	if yes then
 		ya.manager_emit("quit", {})


### PR DESCRIPTION
When I tried this plugin, two last symbols of the text were cut off. I suppose the window frame takes away two symbols, so window width must be set equal to text size + 2.