### PR TITLE
docs: fix and improve helix tips

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -501,28 +501,7 @@ For installation steps, refer to the [installation guide](https://github.com/hun
 
 Yazi can be used as a file picker to browse and open file(s) in your current Helix instance (running in a Zellij session).
 
-Add a keymap to your Helix config, for example <kbd>Ctrl</kbd> + <kbd>y</kbd>:
-
-```toml
-# ~/.config/helix/config.toml
-[keys.normal]
-C-y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open \"%{buffer_name}\""
-```
-
-If you also want the ability to open files in split panes, you can define additional keybindings:
-
-```toml
-# ~/.config/helix/config.toml
-[keys.normal.C-y]
-# Open the file(s) in the current window
-y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open \"%{buffer_name}\""
-# Open the file(s) in a vertical pane
-v = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh vsplit \"%{buffer_name}\""
-# Open the file(s) in a horizontal pane
-h = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh hsplit \"%{buffer_name}\""
-```
-
-Then save the following script as `~/.config/helix/yazi-picker.sh`:
+Save the following script as `~/.config/helix/yazi-picker.sh`:
 
 ```sh
 #!/usr/bin/env bash
@@ -539,7 +518,67 @@ else
 fi
 ```
 
-Note: this uses a floating window, but you should also be able to open a new pane to the side, or in place. Review the Zellij documentation for more info.
+> Note: this uses a floating window, but you should also be able to open a new pane to the side, or in place. Review the [Zellij documentation](https://zellij.dev/documentation/) for more info.
+
+Depending on your Helix version, the configuration differs slightly.
+
+### For Helix > 25.01.1 or Master Branch
+
+> **Note:** A [recently merged PR](https://github.com/helix-editor/helix/pull/12527) introduced the ability to open Yazi directly in the path of the current buffer instead of the project root using parameter expansion. If you're using a version later than 25.01.1 or the master branch, follow the instructions below. Otherwise, refer to the section for Helix <= 25.01.1.
+
+#### Keymap Configuration
+
+Add the following keymap to your Helix configuration file (e.g., <kbd>Ctrl</kbd> + <kbd>y</kbd>):
+
+```toml
+# ~/.config/helix/config.toml
+[keys.normal]
+C-y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open \"%{buffer_name}\""
+```
+
+#### Split Pane Keybindings
+
+If you'd like to open files in split panes, you can define additional keybindings:
+
+```toml
+# ~/.config/helix/config.toml
+[keys.normal.C-y]
+# Open the file(s) in the current window
+y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open \"%{buffer_name}\""
+# Open the file(s) in a vertical split
+v = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh vsplit \"%{buffer_name}\""
+# Open the file(s) in a horizontal split
+h = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh hsplit \"%{buffer_name}\""
+```
+
+### For Helix <= 25.01.1
+
+If you're using Helix version 25.01.1 or earlier, the keymap configuration is slightly different because the feature needed to open Yazi in the current buffer's path is not available.
+
+#### Keymap Configuration
+
+Add the following keymap to your Helix configuration file (e.g., <kbd>Ctrl</kbd> + <kbd>y</kbd>):
+
+```toml
+# ~/.config/helix/config.toml
+[keys.normal]
+C-y = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh open"
+```
+
+#### Split Pane Keybindings
+
+If you'd like to open files in split panes, you can define additional keybindings:
+
+```toml
+# ~/.config/helix/config.toml
+[keys.normal.C-y]
+# Open the file(s) in the current window
+y = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh open"
+# Open the file(s) in a vertical split
+v = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh vsplit"
+# Open the file(s) in a horizontal split
+h = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh hsplit"
+```
 
 Original post: https://github.com/zellij-org/zellij/issues/3018#issuecomment-2086166900, credits to [@rockboynton](https://github.com/rockboynton), [@postsolar](https://github.com/postsolar), [@TheAwiteb](https://github.com/TheAwiteb) and [@Dreaming-Codes](https://github.com/Dreaming-Codes) for sharing and polishing it!
 
@@ -573,7 +612,7 @@ v = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh vsplit'"
 h = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh hsplit'"
 ```
 
-Then save the following script as `~/.config/helix/yazi-picker.sh`:
+Save the following script as `~/.config/helix/yazi-picker.sh`:
 
 ```sh
 #!/usr/bin/env bash

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -506,7 +506,7 @@ Add a keymap to your Helix config, for example <kbd>Ctrl</kbd> + <kbd>y</kbd>:
 ```toml
 # ~/.config/helix/config.toml
 [keys.normal]
-C-y = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh open"
+C-y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open"
 ```
 
 If you also want the ability to open files in split panes, you can define additional keybindings:
@@ -515,11 +515,11 @@ If you also want the ability to open files in split panes, you can define additi
 # ~/.config/helix/config.toml
 [keys.normal.C-y]
 # Open the file(s) in the current window
-y = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh open"
+y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open"
 # Open the file(s) in a vertical split
-v = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh vsplit"
+v = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh vsplit"
 # Open the file(s) in a horizontal split
-h = ":sh zellij run -c -f -x 10% -y 10% --width 80% --height 80% -- bash ~/.config/helix/yazi-picker.sh hsplit"
+h = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh hsplit"
 ```
 
 Then save the following script as `~/.config/helix/yazi-picker.sh`:

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -506,7 +506,7 @@ Add a keymap to your Helix config, for example <kbd>Ctrl</kbd> + <kbd>y</kbd>:
 ```toml
 # ~/.config/helix/config.toml
 [keys.normal]
-C-y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open"
+C-y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open \"%{buffer_name}\""
 ```
 
 If you also want the ability to open files in split panes, you can define additional keybindings:
@@ -515,11 +515,11 @@ If you also want the ability to open files in split panes, you can define additi
 # ~/.config/helix/config.toml
 [keys.normal.C-y]
 # Open the file(s) in the current window
-y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open"
-# Open the file(s) in a vertical split
-v = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh vsplit"
-# Open the file(s) in a horizontal split
-h = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh hsplit"
+y = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh open \"%{buffer_name}\""
+# Open the file(s) in a vertical pane
+v = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh vsplit \"%{buffer_name}\""
+# Open the file(s) in a horizontal pane
+h = ":sh zellij run -c -f -x 10%% -y 10%% --width 80%% --height 80%% -- bash ~/.config/helix/yazi-picker.sh hsplit \"%{buffer_name}\""
 ```
 
 Then save the following script as `~/.config/helix/yazi-picker.sh`:
@@ -527,7 +527,7 @@ Then save the following script as `~/.config/helix/yazi-picker.sh`:
 ```sh
 #!/usr/bin/env bash
 
-paths=$(yazi --chooser-file=/dev/stdout | while read -r; do printf "%q " "$REPLY"; done)
+paths=$(yazi --chooser-file=/dev/stdout "$2" | while read -r line; do echo "$line"; done)
 
 if [[ -n "$paths" ]]; then
 	zellij action toggle-floating-panes

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -608,48 +608,6 @@ v = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh vsplit'"
 h = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh hsplit'"
 ```
 
-Then save the following script as `~/.config/helix/yazi-picker.sh`:
-
-```sh
-#!/usr/bin/env bash
-
-paths=$(yazi --chooser-file=/dev/stdout)
-
-if [[ -n "$paths" ]]; then
-	tmux last-window
-	tmux send-keys Escape
-	tmux send-keys ":$1 $paths"
-	tmux send-keys Enter
-else
-	tmux kill-window -t fx
-fi
-```
-
-## File tree picker in Helix with tmux {#helix-with-tmux}
-
-Yazi can be used as a file picker to browse and open file(s) in your current Helix instance (running in a tmux session).
-
-Add a keymap to your Helix config, for example <kbd>Ctrl</kbd> + <kbd>y</kbd>:
-
-```toml
-# ~/.config/helix/config.toml
-[keys.normal]
-C-y = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh open'"
-```
-
-If you also want the ability to open files in split panes, you can define additional keybindings:
-
-```toml
-# ~/.config/helix/config.toml
-[keys.normal.C-y]
-# Open file(s) in the current window
-y = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh open'"
-# Open file(s) in a vertical split
-v = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh vsplit'"
-# Open file(s) in a horizontal split
-h = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh hsplit'"
-```
-
 Save the following script as `~/.config/helix/yazi-picker.sh`:
 
 ```sh

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -541,7 +541,7 @@ fi
 
 Note: this uses a floating window, but you should also be able to open a new pane to the side, or in place. Review the Zellij documentation for more info.
 
-Original post: https://github.com/zellij-org/zellij/issues/3018#issuecomment-2086166900, credits to [@rockboynton](https://github.com/rockboynton), [@postsolar](https://github.com/postsolar) and [@TheAwiteb](https://github.com/TheAwiteb) for sharing and polishing it!
+Original post: https://github.com/zellij-org/zellij/issues/3018#issuecomment-2086166900, credits to [@rockboynton](https://github.com/rockboynton), [@postsolar](https://github.com/postsolar), [@TheAwiteb](https://github.com/TheAwiteb) and [@Dreaming-Codes](https://github.com/Dreaming-Codes) for sharing and polishing it!
 
 <details>
   <summary>Demonstrate Helix+Zellij+Yazi workflow</summary>

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -608,7 +608,7 @@ v = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh vsplit'"
 h = ":sh tmux new-window -n fx '~/.config/helix/yazi-picker.sh hsplit'"
 ```
 
-Save the following script as `~/.config/helix/yazi-picker.sh`:
+Then save the following script as `~/.config/helix/yazi-picker.sh`:
 
 ```sh
 #!/usr/bin/env bash


### PR DESCRIPTION
Thanks to this helix-editor/helix#12527 now merged helix PR is now possible to open current buffer path instead of project root.