### PR TITLE
fix: incorrect image file extension (png => jpg)

### DIFF
--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -173,7 +173,7 @@ Progress
 
 <details>
 	<summary>Explanation of `tbl_col` and `tbl_cell`</summary>
-	<img src="/img/spot-tbl-explain.png" />
+	<img src="/img/spot-tbl-explain.jpg" />
 </details>
 
 ## [notify] {#notify}


### PR DESCRIPTION
https://github.com/yazi-rs/yazi-rs.github.io/blob/main/static/img/spot-tbl-explain.jpg

Before:
<img width="1149" alt="before" src="https://github.com/user-attachments/assets/7bc615b0-4417-4d91-8fa3-7acff30b5199" />

After:
<img width="1149" alt="after" src="https://github.com/user-attachments/assets/c9d6822c-ba25-4a41-b784-dd833f7fa473" />