### PR TITLE
Fix y shell wrapper for cmd on quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -109,12 +109,14 @@ set tmpfile=%TEMP%\yazi-cwd.%random%
 
 yazi %* --cwd-file="%tmpfile%"
 
-set /p cwd=<"%tmpfile%"
+:: If the file does not exist, then exit
+if not exist "%tmpfile%" exit /b 0
 
+:: If the file exist, then read the content and change the directory
+set /p cwd=<"%tmpfile%"
 if not "%cwd%"=="" (
     cd /d "%cwd%"
 )
-
 del "%tmpfile%"
 ```
 


### PR DESCRIPTION
The script was showing an error when exiting without changing the directory (Ctrl+Q).

This is now fixed.