### PR TITLE
Reset prompt in fish

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -43,6 +43,8 @@ function y
 	yazi $argv --cwd-file="$tmp"
 	if set cwd (command cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
 		builtin cd -- "$cwd"
+		#uncomment the following line if using a keybind to redraw the prompt 
+		#commandline -f repaint
 	end
 	rm -f -- "$tmp"
 end


### PR DESCRIPTION
When the function is launched by a keybind, the prompt is not redrawn automatically, showing the previous directory. Redrawing it, however, flashes the screen with an empty terminal for 1 frame, so it's better to leave it off by default.