### PR TITLE
docs: installation instructions for Fedora and its downstreams

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -289,6 +289,23 @@ Note that these dependencies are quite old on some Debian/Ubuntu versions and ma
 
 If you know how to package Yazi for Debian/Ubuntu and would like to help us submit it, please [file an issue](https://github.com/sxyazi/yazi/issues/new/choose).
 
+## Fedora/Centos Stream 9+/RHEL 9+
+
+Yazi is available as an **unofficial** [COPR repository](https://copr.fedorainfracloud.org/coprs/lihaohong/yazi/). You can install it with the following commands
+
+```sh
+dnf copr enable lihaohong/yazi
+dnf install yazi
+```
+
+Note that `dnf` will install recommended dependencies automatically. To install only yazi, replace the last line with the following instead
+
+```sh
+dnf install yazi --setopt=install_weak_deps=False
+```
+
+If `dnf` complains about "No such command: copr", run `dnf install dnf-plugins-core` and then rerun the commands above.
+
 ## Snapcraft
 
 <a href="https://snapcraft.io/yazi">

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -289,18 +289,20 @@ Note that these dependencies are quite old on some Debian/Ubuntu versions and ma
 
 If you know how to package Yazi for Debian/Ubuntu and would like to help us submit it, please [file an issue](https://github.com/sxyazi/yazi/issues/new/choose).
 
-## Fedora/Centos Stream 9+/RHEL 9+
+## Fedora/Centos Stream 9+/RHEL 9+ {copr}
 
-Yazi is available as an **unofficial** [COPR repository](https://copr.fedorainfracloud.org/coprs/lihaohong/yazi/). You can install it with the following commands
+> [!NOTE]
+> This uses an unofficial COPR repository maintained by [Peter Li](https://github.com/lihaohong6).
 
 ```sh
 dnf copr enable lihaohong/yazi
 dnf install yazi
 ```
 
-Note that `dnf` will install recommended dependencies automatically. To install only yazi, replace the last line with the following instead
+Note that `dnf` will install recommended dependencies automatically, to install only Yazi:
 
 ```sh
+dnf copr enable lihaohong/yazi
 dnf install yazi --setopt=install_weak_deps=False
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -299,7 +299,7 @@ dnf copr enable lihaohong/yazi
 dnf install yazi
 ```
 
-Note that `dnf` will install recommended dependencies automatically, to install only Yazi:
+`dnf` will install recommended dependencies automatically. To install only Yazi:
 
 ```sh
 dnf copr enable lihaohong/yazi


### PR DESCRIPTION
I tested this on my Fedora machine. Both `yazi` and `ya` work, and command line auto-completion works for `zsh`. It should also work for `fish` and `bash`, but I didn't test them.

For CentOS Stream, installation works in a container. I don't have a RHEL subscription, but I got yazi to install on Rocky Linux in a container, so I think RHEL works too.