### PR TITLE
keymap docs - run multiple commands with a single keybinding

### DIFF
--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -28,10 +28,11 @@ Since Yazi selects the first matching key to run, prepend always has a higher pr
 ```toml
 [manager]
 prepend_keymap = [
-	{ on = "<C-a>", run = 'my-fev-command1', desc = "Just for test!" },
+	{ on = "<C-a>", run = "my-fev-command1", desc = "Single command with `Ctrl + a`" },
 ]
 append_keymap = [
-	{ on = [ "g", "a" ], run = 'my-fev-command2', desc = "Just for test!" },
+	{ on = [ "g", "b" ], run = "my-fev-command2",          desc = "Single command with `g => b`" },
+	{ on = "c",          run = [ "command1", "command2" ], desc = "Multiple commands with `c`" }
 ]
 ```
 
@@ -40,16 +41,18 @@ Or in another different style:
 ```toml
 [[manager.prepend_keymap]]
 on   = "<C-a>"
-run  = 'my-fev-command1'
-desc = "Just for test!"
+run  = "my-fev-command1"
+desc = "Single command with `Ctrl + a`"
 
-[[manager.prepend_keymap]]
-on  = [ "g", "a" ]
-run = 'my-fev-command2'
+[[manager.append_keymap]]
+on  = [ "g", "b" ]
+run = "my-fev-command2"
+desc = "Single command with `g => b`"
 
 [[manager.append_keymap]]
 on  = "c"
-run = 'my-fev-command3'
+run = [ "my-fev-command1", "my-fev-command2" ]
+desc = "Multiple commands with `c`"
 ```
 
 But keep in mind that you can only choose one of them, and it cannot be a combination of the two, as TOML language does not allow this:
@@ -57,13 +60,12 @@ But keep in mind that you can only choose one of them, and it cannot be a combin
 ```toml
 [manager]
 prepend_keymap = [
-	{ on = "<C-a>", run = 'my-fev-command1', desc = "Just for test!" },
+	{ on = "<C-a>", run = "my-fev-command1" },
 ]
 
-[[manager.prepend_keymap]]
-on   = [ "g", "a" ]
-run  = 'my-fev-command2'
-desc = "Just for test!"
+[[manager.append_keymap]]
+on  = [ "g", "b" ]
+run = "my-fev-command2"
 ```
 
 When you don't need any default and want to fully customize your keybindings, use `keymap`, for example:
@@ -72,17 +74,8 @@ When you don't need any default and want to fully customize your keybindings, us
 [manager]
 keymap = [
 	# This will override all default keybindings, and just keep the two below.
-	{ on = "<C-a>",      run = 'my-fev-command1', desc = "Just for test!" },
-	{ on = [ "g", "a" ], run = 'my-fev-command2', desc = "Just for test!" },
-]
-```
-
-You can also run multiple commands sequentially with a single keybinding by specifying an array for the `run` value:
-
-```toml
-[manager]
-prepend_keymap = [
-	{ on = "<C-a>", run = ["command1", "command2"], desc = "Run multiple commands" },
+	{ on = "<C-a>",      run = "my-fev-command1" },
+	{ on = [ "g", "b" ], run = "my-fev-command2" },
 ]
 ```
 

--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -84,7 +84,6 @@ You can also run multiple commands sequentially with a single keybinding by spec
 prepend_keymap = [
 	{ on = "<C-a>", run = ["command1", "command2"], desc = "Run multiple commands" },
 ]
-
 ```
 
 ## Key notation {#notation}

--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -77,6 +77,16 @@ keymap = [
 ]
 ```
 
+You can also run multiple commands sequentially with a single keybinding by specifying an array for the `run` value:
+
+```toml
+[manager]
+prepend_keymap = [
+	{ on = "<C-a>", run = ["command1", "command2"], desc = "Run multiple commands" },
+]
+
+```
+
 ## Key notation {#notation}
 
 You can specify one or more keys in the `on` of each keybinding rule, and each key can be represented with the following notations:


### PR DESCRIPTION
To the `keymap.toml` documentation, this PR adds an example of how to run multiple commands using a single keybinding (an array for the `run` value).