### PR TITLE
Update tips to include file sizes in Si notation.

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -641,6 +641,23 @@ run = '''shell --
 '''
 ```
 
+## Show file sizes in Si (base 1000)
+
+Enable it in your `~/.config/yazi/init.lua`:
+
+```lua
+function ya.readable_size(size)
+	local units = { "B", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q" }
+	local base = 1000
+	local i = 1
+	while size > base and i < #units do
+		size = size / base
+		i = i + 1
+	end
+	return string.format("%.1f%s", size, units[i]):gsub("[.,]0", "", 1)
+end
+```
+
 ## Make Yazi even faster than fast {#make-yazi-even-faster}
 
 While Yazi is already fast, there is still plenty of room for optimization for specific users or under certain conditions:


### PR DESCRIPTION
Core tools like du or ls allow showing the file sizes in Si notation. This makes Yazi consistent for users who prefer that.

Requested-by: https://github.com/sxyazi/yazi/issues/2567