### PR TITLE
docs: update default z/Z bindings in quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -170,8 +170,8 @@ Further navigation commands can be found in the table below.
 | <kbd>J</kbd>                | Seek down 5 units in the preview                                           |
 | <kbd>g</kbd> ⇒ <kbd>g</kbd> | Move cursor to the top                                                     |
 | <kbd>G</kbd>                | Move cursor to the bottom                                                  |
-| <kbd>z</kbd>                | [Cd][manager.cd] to a directory via zoxide                                 |
-| <kbd>Z</kbd>                | [Cd][manager.cd] to a directory or [reveal][manager.reveal] a file via fzf |
+| <kbd>z</kbd>                | [Cd][manager.cd] to a directory or [reveal][manager.reveal] a file via fzf |
+| <kbd>Z</kbd>                | [Cd][manager.cd] to a directory via zoxide                                 |
 
 [manager.cd]: /docs/configuration/keymap#manager.cd
 [manager.reveal]: /docs/configuration/keymap#manager.reveal


### PR DESCRIPTION
z / Z were reversed in #2553, but the corresponding documentation doesn't seem to have been updated.