### PR TITLE
docs: add page for built-in plugins fzf and zoxide

### DIFF
--- a/docs/plugins/builtins.md
+++ b/docs/plugins/builtins.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 4
+description: Learn how to configure Yazi's built-in plugins.
+---
+
+# Builtins
+
+Yazi comes with useful built-in plugins to help enhance your workflow without extra setup. This page introduces these built-in plugins and their available configuration options.
+
+## `fzf.lua` {#fzf}
+
+Integrate the power of [`fzf`](https://github.com/junegunn/fzf) into Yazi, allowing you to swiftly search and navigate through files and directories with fuzzy matching.
+
+Source code: https://github.com/sxyazi/yazi/blob/main/yazi-plugin/preset/plugins/fzf.lua
+
+### Usage
+
+How to invoke fzf:
+
+- Press <kbd>z</kbd> for quick file subtree navigation within CWD.
+- Or, press <kbd>z</kbd> for quick navigation among selected items, if you are in selection mode.
+
+If you exit fzf with a single-selected file:
+
+- [`reveal`](/docs/configuration/keymap#manager.reveal) the file.
+- Or, [`cd`](/docs/configuration/keymap#manager.cd) to it if it's a directory.
+
+If you exit fzf with multiple-selected files:
+
+- Select the files chosen by fzf in Yazi.
+- Or, deselect the files chosen by fzf in Yazi, if you are in selection mode.
+
+## `zoxide.lua` {#zoxide}
+
+Enhance your experience of historical directories navigation with external shell, through [`zoxide`](https://github.com/ajeetdsouza/zoxide), a smarter `cd`.
+
+Source code: https://github.com/sxyazi/yazi/blob/main/yazi-plugin/preset/plugins/zoxide.lua
+
+### Usage
+
+Click <kbd>Z</kbd> to launch the interactive zoxide UI. Please ensure that:
+
+1. You have installed the latest version of zoxide.
+2. You have installed the latest version of [fzf](https://github.com/junegunn/fzf), which is a dependency of zoxide.
+3. You have correctly configured zoxide for your shell according to [its documentation](https://github.com/ajeetdsouza/zoxide?tab=readme-ov-file#installation).
+
+### Options
+
+| Option             | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| `update_db` (bool) | Add the path to zoxide database whenever you switches CWD. |
+
+You can _optionally_ change certain options in your `init.lua` like this:
+
+```lua
+-- ~/.config/yazi/init.lua
+require("zoxide"):setup {
+	update_db = true,
+}
+```

--- a/docs/plugins/config.md
+++ b/docs/plugins/config.md
@@ -1,55 +1,8 @@
-# Built-In Plugins
-
-Yazi comes with useful built-in plugins to help enhance your workflow without extra setup. This page introduces the two built-in plugins and their available configuration options.
-
-> If you find any issues or have suggestions for improvements, feel free to [open an issue](https://github.com/yazi-rs) or contribute via a pull request.
-
-## fzf Plugin
-
-The **fzf** plugin integrates the power of [fzf](https://github.com/junegunn/fzf) directly into Yazi, allowing you to swiftly search and navigate through files and directories with fuzzy matching.
-
-### Features
-
-- **Quick file searching:** Use fuzzy matching to find files on the fly.
-- **Seamless integration:** The plugin is designed to work out-of-the-box with Yazi’s command palette.
-- **Minimal setup:** No additional configuration is required to start using fzf functionality.
-
-### Usage
-
-When invoking file searches or using commands that trigger fzf, Yazi automatically routes the query through the plugin. This provides a fast and smooth experience without leaving the terminal.
-
-*Note: As of now, there are no extra configuration options for the fzf plugin. Future enhancements may introduce more fine-grained controls.*
-
+---
+sidebar_position: 5
+description: Learn how to use Yazi's Lua API.
 ---
 
-## zoxide Plugin
+# Config
 
-The **zoxide** plugin enhances your directory navigation by integrating with [zoxide](https://github.com/ajeetdsouza/zoxide), a smarter replacement for the conventional `cd` command.
-
-### Features
-
-- **Smart directory jumping:** Leverages zoxide’s tracking to jump to frequently or recently visited directories.
-- **Automatic database updates:** Optionally updates zoxide’s internal database each time you use the `cd` command within Yazi.
-
-### Configuration Options
-
-The key configuration option for the zoxide plugin is `update_db`, which controls whether Yazi should update zoxide’s database automatically. This gives you control over the behavior of your directory change tracking.
-
-#### Example Configuration
-
-Below is an example snippet using TOML syntax. Adjust it if you use YAML or another configuration format:
-
-```toml
-[plugins.zoxide]
-# Set to true so that Yazi updates zoxide's database when changing directories.
-update_db = true
-```
-
-- **update_db:**  
-  - **Type:** Boolean  
-  - **Default:** Typically set to `true`  
-  - **Purpose:** When enabled, every time you use the `cd` command within Yazi, the zoxide database will be updated automatically. This ensures that your recent and frequently used directories are tracked accurately.
-
-### Usage
-
-Once enabled in your configuration, you can enjoy smooth directory navigation powered by zoxide. For instance, using a simple `cd` command in Yazi will both change your working directory and maintain an updated navigation history as managed by zoxide.
+TODO

--- a/docs/plugins/config.md
+++ b/docs/plugins/config.md
@@ -1,8 +1,55 @@
----
-sidebar_position: 4
-description: Learn how to use Yazi's Lua API.
+# Built-In Plugins
+
+Yazi comes with useful built-in plugins to help enhance your workflow without extra setup. This page introduces the two built-in plugins and their available configuration options.
+
+> If you find any issues or have suggestions for improvements, feel free to [open an issue](https://github.com/yazi-rs) or contribute via a pull request.
+
+## fzf Plugin
+
+The **fzf** plugin integrates the power of [fzf](https://github.com/junegunn/fzf) directly into Yazi, allowing you to swiftly search and navigate through files and directories with fuzzy matching.
+
+### Features
+
+- **Quick file searching:** Use fuzzy matching to find files on the fly.
+- **Seamless integration:** The plugin is designed to work out-of-the-box with Yazi’s command palette.
+- **Minimal setup:** No additional configuration is required to start using fzf functionality.
+
+### Usage
+
+When invoking file searches or using commands that trigger fzf, Yazi automatically routes the query through the plugin. This provides a fast and smooth experience without leaving the terminal.
+
+*Note: As of now, there are no extra configuration options for the fzf plugin. Future enhancements may introduce more fine-grained controls.*
+
 ---
 
-# Config
+## zoxide Plugin
 
-TODO
+The **zoxide** plugin enhances your directory navigation by integrating with [zoxide](https://github.com/ajeetdsouza/zoxide), a smarter replacement for the conventional `cd` command.
+
+### Features
+
+- **Smart directory jumping:** Leverages zoxide’s tracking to jump to frequently or recently visited directories.
+- **Automatic database updates:** Optionally updates zoxide’s internal database each time you use the `cd` command within Yazi.
+
+### Configuration Options
+
+The key configuration option for the zoxide plugin is `update_db`, which controls whether Yazi should update zoxide’s database automatically. This gives you control over the behavior of your directory change tracking.
+
+#### Example Configuration
+
+Below is an example snippet using TOML syntax. Adjust it if you use YAML or another configuration format:
+
+```toml
+[plugins.zoxide]
+# Set to true so that Yazi updates zoxide's database when changing directories.
+update_db = true
+```
+
+- **update_db:**  
+  - **Type:** Boolean  
+  - **Default:** Typically set to `true`  
+  - **Purpose:** When enabled, every time you use the `cd` command within Yazi, the zoxide database will be updated automatically. This ensures that your recent and frequently used directories are tracked accurately.
+
+### Usage
+
+Once enabled in your configuration, you can enjoy smooth directory navigation powered by zoxide. For instance, using a simple `cd` command in Yazi will both change your working directory and maintain an updated navigation history as managed by zoxide.


### PR DESCRIPTION
This PR adds documentation for the built-in plugins fzf and zoxide, including features, usage, and update_db config option.

Closes #71