### PR TITLE
docs(tips): send selected files with neomutt

### DIFF
--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -360,7 +360,7 @@ prepend_previewers = [
 
 append_previewers = [
 	# My fallback previewer
-	{ name = "*" , run = "binary" },
+	{ name = "*", run = "binary" },
 ]
 ```
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -600,7 +600,7 @@ fi
 
 ## Email selected files
 
-To send selected files using Thunderbird, with a keybinding <kbd>Ctrl</kbd> + <kbd>m</kbd>:
+To send selected files using [Thunderbird](https://www.thunderbird.net), with a keybinding <kbd>Ctrl</kbd> + <kbd>m</kbd>:
 
 ```toml
 # ~/.config/yazi/keymap.toml
@@ -612,17 +612,13 @@ run = '''shell --
 '''
 ```
 
-Or, use the Neomutt terminal email client for sending the selected files with <kbd>Ctrl</kbd> + <kbd>m</kbd>:
+Or, use the [NeoMutt](https://neomutt.org) command-line mail client:
 
 ```toml
 # ~/.config/yazi/keymap.toml
 [[manager.prepend_keymap]]
-on = "<C-m>"
-run = '''
-	shell --block '
-        neomutt -a "$@"
-    '
-'''
+on  = "<C-m>"
+run = 'shell --block -- neomutt -a "$@"'
 ```
 
 ## Make Yazi even faster than fast {#make-yazi-even-faster}

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -598,17 +598,31 @@ else
 fi
 ```
 
-## Email selected files using Thunderbird
+## Email selected files
 
-To send selected files using Thunderbird, with a keybinding <kbd>Ctrl</kbd> + <kbd>e</kbd>:
+To send selected files using Thunderbird, with a keybinding <kbd>Ctrl</kbd> + <kbd>m</kbd>:
 
 ```toml
 # ~/.config/yazi/keymap.toml
 [[manager.prepend_keymap]]
-on  = "<C-e>"
+on  = "<C-m>"
 run = '''shell --
 	paths=$(for p in "$@"; do echo "$p"; done | paste -s -d,)
 	thunderbird -compose "attachment='$paths'"
+'''
+```
+
+Or, use the Neomutt terminal email client for sending the selected files with <kbd>Ctrl</kbd> + <kbd>m</kbd>:
+
+```toml
+# ~/.config/yazi/keymap.toml
+[[manager.prepend_keymap]]
+on = "<C-m>"
+run = '''
+	shell '
+        paths=$(for p in "$@"; do echo "$p"; done | tr "\n" " ")
+        ghostty -e neomutt -a $paths
+    '
 '''
 ```
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -620,8 +620,7 @@ Or, use the Neomutt terminal email client for sending the selected files with <k
 on = "<C-m>"
 run = '''
 	shell --block '
-        paths=$(for p in "$@"; do echo "$p"; done | tr "\n" " ")
-        neomutt -a $paths
+        neomutt -a "$@"
     '
 '''
 ```

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -619,9 +619,9 @@ Or, use the Neomutt terminal email client for sending the selected files with <k
 [[manager.prepend_keymap]]
 on = "<C-m>"
 run = '''
-	shell '
+	shell --block '
         paths=$(for p in "$@"; do echo "$p"; done | tr "\n" " ")
-        ghostty -e neomutt -a $paths
+        neomutt -a $paths
     '
 '''
 ```


### PR DESCRIPTION
changed `<C-e>` to `<C-m>` because it was conflicting with a default keymap