### PR TITLE
fixed whitespace handling in the shell wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -27,7 +27,8 @@ We suggest using this `y` shell wrapper that provides the ability to change the 
 function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
 	yazi "$@" --cwd-file="$tmp"
-	if cwd="$(command cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+	IFS= read -r -d '' cwd < "$tmp"
+	if [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
 		builtin cd -- "$cwd"
 	fi
 	rm -f -- "$tmp"
@@ -41,7 +42,7 @@ function y() {
 function y
 	set tmp (mktemp -t "yazi-cwd.XXXXXX")
 	yazi $argv --cwd-file="$tmp"
-	if set cwd (command cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
+	if read -z cwd < "$tmp"; and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
 		builtin cd -- "$cwd"
 	end
 	rm -f -- "$tmp"
@@ -73,7 +74,7 @@ edit:add-var y~ {|@argv|
 	use file
 	var tmp = (os:temp-file)
 	yazi $@argv --cwd-file=$tmp[name]
-	var cwd = (str:trim-space (slurp < $tmp))
+	var cwd = (slurp < $tmp)
 	file:close $tmp
 	os:remove $tmp[name]
 	if (and (not-eq $cwd '') (not-eq $cwd $pwd)) {
@@ -129,7 +130,7 @@ def _y(args):
     args.append(f"--cwd-file={tmp}")
     $[yazi @(args)]
     with open(tmp) as f:
-        cwd = f.read().strip()
+        cwd = f.read()
     if cwd != $PWD:
         cd @(cwd)
     rm -f -- @(tmp)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,9 +28,7 @@ function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
 	yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
-	if [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
-		builtin cd -- "$cwd"
-	fi
+	[ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && builtin cd -- "$cwd"
 	rm -f -- "$tmp"
 }
 ```


### PR DESCRIPTION
# The Problem

The shell wrappers currently fail for paths with trailing whitespace.

# How to reproduce

```bash
mkdir $'foo\n'
y
```

Then navigate to `foo\n` and press <kbd>q</kbd>.

# What I did to fix it

- I replaced `cwd=$(...)` with `read` in bash/zsh/fish.

- I removed the `str:trim-space` in elvish and the `.strip()` in xonsh.

# What I didn't do

- nushell's `open` appears to preserve whitespace, but then `cd` barfs on it. I don't know enough nushell to fix this.

- Powershell should be fine since it uses `Get-Content`, but I didn't test it.

- I also didn't touch cmd.