### PR TITLE
Improved types

### DIFF
--- a/scripts/typegen.js
+++ b/scripts/typegen.js
@@ -24,9 +24,9 @@ const STUBS = `
 ---@class (exact) Recv
 ---@field recv fun(self: self): string
 
----@type Command | fun(command: string): Command
+---@type Command
 Command = Command
----@type fun(path: string): Url
+---@type Url
 Url = Url
 ---@type cx
 cx = cx

--- a/scripts/typegen.js
+++ b/scripts/typegen.js
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs"
 const STUBS = `
 -- luacheck: globals Command Url cx fs ps rt th ui ya
 
----@alias Color string
+---@alias Color "reset"|"black"|"white"|"red"|"lightred"|"green"|"lightgreen"|"yellow"|"lightyellow"|"blue"|"lightblue"|"magenta"|"lightmagenta"|"cyan"|"lightcyan"|"gray"|"darkgray"|string
 ---@alias Position integer
 ---@alias Stdio integer
 
@@ -24,9 +24,9 @@ const STUBS = `
 ---@class (exact) Recv
 ---@field recv fun(self: self): string
 
----@type Command
+---@type Command | fun(command: string): Command
 Command = Command
----@type Url
+---@type fun(path: string): Url
 Url = Url
 ---@type cx
 cx = cx

--- a/scripts/typegen.js
+++ b/scripts/typegen.js
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs"
 const STUBS = `
 -- luacheck: globals Command Url cx fs ps rt th ui ya
 
----@alias Color "reset"|"black"|"white"|"red"|"lightred"|"green"|"lightgreen"|"yellow"|"lightyellow"|"blue"|"lightblue"|"magenta"|"lightmagenta"|"cyan"|"lightcyan"|"gray"|"darkgray"|string
+---@alias Color string|"reset"|"black"|"white"|"red"|"lightred"|"green"|"lightgreen"|"yellow"|"lightyellow"|"blue"|"lightblue"|"magenta"|"lightmagenta"|"cyan"|"lightcyan"|"gray"|"darkgray"
 ---@alias Stdio integer
 
 ---@alias Sendable nil|boolean|number|string|Url|{ [Sendable]: Sendable }


### PR DESCRIPTION
These changes are based on the Yazi types file that I maintain together with my augment-command.yazi plugin.

The Color type now shows all the supported named colours like “blue” and “red”.

The Url global is now a function that returns a Url object, as it is not a Url object by itself and is never used that way. This allows the normal usage of `Url(“path/to/file”)` to be properly typed.

The Command global is now either the Command object or a function that returns a Command object. This allows the usage of `Command(“shell_command”)` to be properly typed.