### PR TITLE
docs(resources.md): Add gvfs.yazi, remove predecated/archived simple-mtpfs.yazi

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -86,7 +86,7 @@ File actions:
 - [lazygit.yazi](https://github.com/Lil-Dank/lazygit.yazi) - Manage Git directories with [lazygit](https://github.com/jesseduffield/lazygit) with a quick shortcut.
 - [sudo.yazi](https://github.com/TD-Sky/sudo.yazi) - Execute specific file operations with `sudo` privileges.
 - [restore.yazi](https://github.com/boydaihungst/restore.yazi) - Restore/recover latest deleted files/folders using `trash-cli`.
-- [simple-mtpfs.yazi](https://github.com/boydaihungst/simple-mtpfs.yazi) - Mounting MTP devices (Android, Camera, etc) using `simple-mtpfs` (for Linux only).
+- [gvfs.yazi](https://github.com/boydaihungst/gvfs.yazi) - Mount and manage MTP, GPhoto2 (PTP) devices (Android, Cameras, etc), SMB, SFTP, NFS, FTP, Google Drive, DNS-SD, DAV (WebDAV), AFP, AFC (Linux only). List of [supported protocals](https://wiki.gnome.org/Projects(2f)gvfs(2f)schemes.html).
 - [kdeconnect-send.yazi](https://github.com/Deepak22903/kdeconnect-send.yazi) - Send selected files to your smartphone or other devices using KDE Connect.
 
 Clipboard:


### PR DESCRIPTION
Since I no longer maintain `simple-mtpfs.yazi`, it should be removed. Users can now use `gvfs.yazi` as a replacement.