### PR TITLE
Resources: `git-files.yazi` plugin

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -117,6 +117,7 @@ Clipboard:
 `search` enhancements:
 
 - [vcs-files.yazi](https://github.com/yazi-rs/plugins/tree/main/vcs-files.yazi) - Show Git file changes.
+- [git-files.yazi](https://github.com/ktunprasert/git-files.yazi) - Show Git file changes (with untracked, via `git status --porcelain`)
 
 `paste` enhancements:
 


### PR DESCRIPTION
Thanks for yazi it's great!

I wanted the `vcs-files` plugin to also show untracked files as well. I don't know if the vision for that plugin is to show only diff files so I made another plugin that is inclusive.

[keyviz_2025-06-11_20-26-06.webm](https://github.com/user-attachments/assets/af9559c2-f30c-40da-bfb1-97370bdbee03)

first one shows `git status --porcelain` backed
second one shows `git diff --name-only` as your original implementation