### PR TITLE
Add missing tmux option for image-preview

### DIFF
--- a/docs/image-preview.md
+++ b/docs/image-preview.md
@@ -57,6 +57,7 @@ it will automatically use the "Window system protocol" to display images - this 
 To enable Yazi's image preview to work correctly in tmux, add the following 4 options to your `tmux.conf`:
 
 ```sh
+set -g default-terminal "tmux-256color"
 set -g allow-passthrough on
 set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM


### PR DESCRIPTION
The option 

`set -g default-terminal "tmux-256color" `

was added with commit ae6d5fc5 but removed somewhere along the line - proof of this is that in the line above it states `4 options` and not only 3.