### PR TITLE
Fix number of tmux options for image preview

### DIFF
--- a/docs/image-preview.md
+++ b/docs/image-preview.md
@@ -54,7 +54,7 @@ it will automatically use the "Window system protocol" to display images - this 
 
 ## tmux users {#tmux}
 
-To enable Yazi's image preview to work correctly in tmux, add the following 4 options to your `tmux.conf`:
+To enable Yazi's image preview to work correctly in tmux, add the following 3 options to your `tmux.conf`:
 
 ```sh
 set -g allow-passthrough on


### PR DESCRIPTION
Since there are clearly only 3 options needed for `tmux`, I fixed the typo in the readme.