### PR TITLE
Powershell integration that is ConstraintLanguageMode compatible

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -85,15 +85,16 @@ edit:add-var y~ {|@argv|
   <TabItem value="powershell" label="PowerShell">
 
 ```powershell
-function y {
-    $tmp = [System.IO.Path]::GetTempFileName()
+  function y {
+    $tmp =  New-TemporaryFile | foreach FullName
     yazi $args --cwd-file="$tmp"
     $cwd = Get-Content -Path $tmp -Encoding UTF8
     if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
-        Set-Location -LiteralPath ([System.IO.Path]::GetFullPath($cwd))
+      $path = Get-Item -LiteralPath $cwd -ea Stop
+      Set-Location -LiteralPath $path.FullName
     }
     Remove-Item -Path $tmp
-}
+  }
 ```
 
   </TabItem>

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -86,14 +86,14 @@ edit:add-var y~ {|@argv|
 
 ```powershell
 function y {
-  $tmp = New-TemporaryFile | foreach FullName
-  yazi $args --cwd-file="$tmp"
-  $cwd = Get-Content -Path $tmp -Encoding UTF8
-  if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
-    $path = Get-Item -LiteralPath $cwd -ea Stop
-    Set-Location -LiteralPath $path.FullName
-  }
-  Remove-Item -Path $tmp
+    $tmp = New-TemporaryFile | foreach FullName
+    yazi $args --cwd-file="$tmp"
+    $cwd = Get-Content -Path $tmp -Encoding UTF8
+    if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
+        $path = Get-Item -LiteralPath $cwd -ea Stop
+        Set-Location -LiteralPath $path.FullName
+    }
+    Remove-Item -Path $tmp
 }
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -85,16 +85,16 @@ edit:add-var y~ {|@argv|
   <TabItem value="powershell" label="PowerShell">
 
 ```powershell
-  function y {
-    $tmp =  New-TemporaryFile | foreach FullName
-    yazi $args --cwd-file="$tmp"
-    $cwd = Get-Content -Path $tmp -Encoding UTF8
-    if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
-      $path = Get-Item -LiteralPath $cwd -ea Stop
-      Set-Location -LiteralPath $path.FullName
-    }
-    Remove-Item -Path $tmp
+function y {
+  $tmp = New-TemporaryFile | foreach FullName
+  yazi $args --cwd-file="$tmp"
+  $cwd = Get-Content -Path $tmp -Encoding UTF8
+  if (-not [String]::IsNullOrEmpty($cwd) -and $cwd -ne $PWD.Path) {
+    $path = Get-Item -LiteralPath $cwd -ea Stop
+    Set-Location -LiteralPath $path.FullName
   }
+  Remove-Item -Path $tmp
+}
 ```
 
   </TabItem>


### PR DESCRIPTION
If yazi is used in the ConstraintLanguageMode the `y` function needs to use Powershell-native way of doing things. The new version would work both in regular and in the constraint modes.
