### PR TITLE
fix: SC2164 for y shell wrapper bash

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,7 +28,7 @@ function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
 	yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
-	[ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && builtin cd -- "$cwd"
+	[ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && (builtin cd -- "$cwd" || return)
 	rm -f -- "$tmp"
 }
 ```


### PR DESCRIPTION
Fixes [SC2164](https://www.shellcheck.net/wiki/SC2164)

![image](https://github.com/user-attachments/assets/c68def10-89f2-4a0a-98ef-796168340517)
