### PR TITLE
Enable AnnouncementBar only for "docs"

### DIFF
--- a/src/theme/AnnouncementBar/index.tsx
+++ b/src/theme/AnnouncementBar/index.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import { useLocation } from "@docusaurus/router"
+import DefaultAnnouncementBar from "@theme-original/AnnouncementBar"
+
+export default function AnnouncementBarWrapper(props) {
+	const { pathname } = useLocation()
+
+	// Only show `announcementBar` on /docs or /docs/*
+	if (!pathname.startsWith("/docs")) {
+		return null
+	}
+	return <DefaultAnnouncementBar {...props} />
+}


### PR DESCRIPTION
"Edit this page" is only available for https://yazi-rs.github.io/docs/

So it makes sense to enable the "announcementBar" only for above url to avoid confusion.