### PR TITLE
Update Arch installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,8 +40,7 @@ Most packages on this page are maintained by the community, and they **_may not 
 ## Arch Linux {#arch}
 
 ```sh
-sudo pacman -S yazi ffmpeg 7zip jq poppler fd ripgrep fzf zoxide imagemagick
-paru -S resvg
+sudo pacman -S yazi ffmpeg 7zip jq poppler fd ripgrep fzf zoxide resvg imagemagick
 ```
 
 If you want to use the latest Git version, you can install it from [AUR](https://aur.archlinux.org/packages/yazi-git/) or [Arch Linux CN](https://github.com/archlinuxcn/repo/):


### PR DESCRIPTION
Resvg has been moved out of the AUR to the extra repository.

https://gitlab.archlinux.org/archlinux/packaging/packages/yazi/-/merge_requests/12#note_290066

https://archlinux.org/packages/extra/x86_64/resvg/