### PR TITLE
Add documentation for 7z RAR support in nix installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -202,6 +202,15 @@ programs.yazi = {
 };
 ```
 
+To enable RAR support from 7z, you can override the 7z dependency in the package:
+
+```nix
+environment.systemPackages = with pkgs; [
+	(yazi.override {_7zz = _7zz-rar; })
+];
+
+```
+
 ### Cache
 
 Pre-built artifacts are served at https://yazi.cachix.org, so that Nix users don't have to build Yazi on their machine.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,6 +74,7 @@ Or add the following to your configuration:
 # configuration.nix
 environment.systemPackages = with pkgs; [
 	yazi
+	# (yazi.override {_7zz = _7zz-rar; }) # use this to enable rar support in yazi
 ];
 ```
 
@@ -166,7 +167,11 @@ The upstream repository provides a flake so that Nix users can easily keep up wi
 			nixos = nixpkgs.lib.nixosSystem {
 				modules = [
 					({ pkgs, ... }: {
-						environment.systemPackages = [ yazi.packages.${pkgs.system}.default ];
+						environment.systemPackages = [
+							yazi.packages.${pkgs.system}.default
+							# (yazi.packages.${pkgs.system}.default.override {_7zz = pkgs._7zz-rar; })
+							# use this to enable rar support in yazi
+						];
 					})
 				];
 			};
@@ -178,7 +183,11 @@ The upstream repository provides a flake so that Nix users can easily keep up wi
 				pkgs = nixpkgs.legacyPackages.x86_64-linux;
 				modules = [
 					({ pkgs, ... }: {
-						home.packages = [ yazi.packages.${pkgs.system}.default ];
+						home.packages = [
+							yazi.packages.${pkgs.system}.default
+							# (yazi.packages.${pkgs.system}.default.override {_7zz = pkgs._7zz-rar; })
+							# use this to enable rar support in yazi
+						];
 					})
 				];
 			};
@@ -199,16 +208,8 @@ A module is also available for both NixOS and home-manager:
 programs.yazi = {
 	enable = true;
 	package = yazi.packages.${pkgs.system}.default; # if you use overlays, you can omit this
+	# package = (yazi.packages.${pkgs.system}.default.override {_7zz = pkgs._7zz-rar; }) # use this to enable rar support in yazi
 };
-```
-
-To enable RAR support from 7z, you can override the 7z dependency in the package:
-
-```nix
-environment.systemPackages = with pkgs; [
-	(yazi.override {_7zz = _7zz-rar; })
-];
-
 ```
 
 ### Cache

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,8 +73,9 @@ Or add the following to your configuration:
 ```nix
 # configuration.nix
 environment.systemPackages = with pkgs; [
-	yazi
-	# (yazi.override {_7zz = _7zz-rar; }) # use this to enable rar support in yazi
+	(yazi.override {
+		_7zz = _7zz-rar;  # Support for RAR extraction
+	})
 ];
 ```
 
@@ -168,9 +169,9 @@ The upstream repository provides a flake so that Nix users can easily keep up wi
 				modules = [
 					({ pkgs, ... }: {
 						environment.systemPackages = [
-							yazi.packages.${pkgs.system}.default
-							# (yazi.packages.${pkgs.system}.default.override {_7zz = pkgs._7zz-rar; })
-							# use this to enable rar support in yazi
+							(yazi.packages.${pkgs.system}.default.override {
+								_7zz = pkgs._7zz-rar;  # Support for RAR extraction
+							})
 						];
 					})
 				];
@@ -184,9 +185,9 @@ The upstream repository provides a flake so that Nix users can easily keep up wi
 				modules = [
 					({ pkgs, ... }: {
 						home.packages = [
-							yazi.packages.${pkgs.system}.default
-							# (yazi.packages.${pkgs.system}.default.override {_7zz = pkgs._7zz-rar; })
-							# use this to enable rar support in yazi
+							(yazi.packages.${pkgs.system}.default.override {
+								_7zz = pkgs._7zz-rar;  # Support for RAR extraction
+							})
 						];
 					})
 				];
@@ -207,8 +208,10 @@ A module is also available for both NixOS and home-manager:
 ```nix
 programs.yazi = {
 	enable = true;
-	package = yazi.packages.${pkgs.system}.default; # if you use overlays, you can omit this
-	# package = (yazi.packages.${pkgs.system}.default.override {_7zz = pkgs._7zz-rar; }) # use this to enable rar support in yazi
+	# You can omit this if you use overlays
+	package = yazi.packages.${pkgs.system}.default.override {
+		_7zz = pkgs._7zz-rar;  # Support for RAR extraction
+	};
 };
 ```
 


### PR DESCRIPTION
Added note for overriding 7z dependency in nix, for enabling 7z RAR support.
Without this, RAR files cannot be correctly extracted by yazi in nix.