### PR TITLE
Add clippy.yazi to resources.md

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -97,6 +97,7 @@ Clipboard:
 - [system-clipboard.yazi](https://github.com/orhnk/system-clipboard.yazi) - Cross platform implementation of a simple system clipboard.
 - [wl-clipboard.yazi](https://github.com/grappas/wl-clipboard.yazi) - Wayland implementation of a simple system clipboard.
 - [path-from-root.yazi](https://github.com/aresler/path-from-root.yazi) - Copy file path relative to git root
+- [clippy.yazi](https://github.com/gallardo994/clippy.yazi) - Copy files to clipboard with Clippy on macOS
 
 `filter` enhancements:
 


### PR DESCRIPTION
Added clippy.yazi URL to resources.md (clipboard section). The plugin is based on system-clipboard.yazi, but utilizes Clippy. 

The original motivation to use Clippy instead of Clipboard _specifically_ on MacOS is to avoid this particular bug: https://github.com/Slackadays/Clipboard/issues/234