### PR TITLE
Fix error in "plugin" command for input layer

### DIFF
--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -773,7 +773,7 @@ Kill the specified range of characters. This command is only available in insert
 
 ### `plugin` {#input.plugin}
 
-See [Functional plugin](/docs/plugins/overview#functional-plugin). This command is only available in insert mode.
+See [Functional plugin](/docs/plugins/overview#functional-plugin). This command is only available in normal mode.
 
 ### `noop` {#input.noop}
 


### PR DESCRIPTION
From my testing, "plugin" command for input layer only works in normal mode.  I assume this is a documentation error rather than a bug so I am making the edit here.