### PR TITLE
fix: make swaybg work on more WMs

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -184,11 +184,12 @@ run  = 'hyprctl hyprpaper reload ,"$0"'
 for  = "linux"
 desc = "Set as wallpaper"
 
-# Linux: Sway + Swaybg
+# Linux: Swaybg
 [[opener.set-wallpaper]]
-run  = 'cp "$0" "$HOME/.config/sway/wallpaper" && killall swaybg && swaymsg exec "swaybg -i $HOME/.config/sway/wallpaper"'
+run  = 'killall swaybg; swaybg -m fill -i "$0"'
 for  = "linux"
 desc = "Set as wallpaper"
+orphan = true
 
 # macOS
 [[opener.set-wallpaper]]


### PR DESCRIPTION
swaybg can be used independent of sway, ive tested the new keybinding with niri wm

this also removes copying files to your config directory and uses the hovered file as argument