### PR TITLE
Add Posix Shell Wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -63,7 +63,7 @@ def --env y [...args] {
 ```
 
   </TabItem>
-	<TabItem value="posix" label="POSIX" default>
+  <TabItem value="posix" label="POSIX">
 
 ```sh
 y() {


### PR DESCRIPTION
Adds documentation for a shell wrapper compatible with POSIX-compliant shells such as `dash`.
Do note that this addition already incorporates what #264 has suggested for the existing wrappers.

Furthermore, even though it's already been closed, this would resolve #248.