### PR TITLE
docs: Update whoosh.yazi link from GitHub to GitLab

### DIFF
--- a/versioned_docs/version-25.5.31/resources.md
+++ b/versioned_docs/version-25.5.31/resources.md
@@ -67,7 +67,7 @@ Bookmarks:
 - [simple-tag.yazi](https://github.com/boydaihungst/simple-tag.yazi) - Tagging feature for Linux, macOS and Windows!
 - [yamb.yazi](https://github.com/h-hg/yamb.yazi) - Yet another bookmarks plugins. It supports persistence, jumping by a key, jumping by [fzf](https://github.com/junegunn/fzf).
 - [bunny.yazi](https://github.com/stelcodes/bunny.yazi) - Bookmarks menu with both persistent and ephemeral bookmarks, fuzzy searching, going back to previous directory, and changing to a directory open in another tab.
-- [whoosh.yazi](https://github.com/WhoSowSee/whoosh.yazi) - Advanced bookmark manager with persistent/temporary bookmarks, directory history, fzf integration, path truncation, and cross-platform support. Jump between locations instantly with keys or fuzzy search.
+- [whoosh.yazi](https://gitlab.com/WhoSowSee/whoosh.yazi) - Advanced bookmark manager with persistent/temporary bookmarks, directory history, fzf integration, path truncation, and cross-platform support. Jump between locations instantly with keys or fuzzy search.
 
 Tabs:
 


### PR DESCRIPTION
The WhoSowSee github account was deleted few days ago.

The gitlab repo (https://gitlab.com/WhoSowSee/whoosh.yazi) had recent doc updates, though I am not sure if the owner is the same. And we cannot install such nice plugin with `ya pkg` anymore.

Please decide whether to update the reference.

Closes #299