### PR TITLE
Fixed key bindings for zoxide and fzf

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -183,8 +183,8 @@ Further navigation commands can be found in the table below.
 | <kbd>J</kbd>                    | Seek down 5 units in the preview                                                  |
 | <kbd>g</kbd> ⇒ <kbd>g</kbd>     | Move cursor to the top                                                            |
 | <kbd>G</kbd>                    | Move cursor to the bottom                                                         |
-| <kbd>z</kbd>                    | [Cd][mgr.cd] to a directory or [reveal][mgr.reveal] a file via fzf                |
-| <kbd>Z</kbd>                    | [Cd][mgr.cd] to a directory via zoxide                                            |
+| <kbd>z</kbd>                    | [Cd][mgr.cd] to a directory via zoxide                                            |
+| <kbd>Z</kbd>                    | [Cd][mgr.cd] to a directory or [reveal][mgr.reveal] a file via fzf                |
 | <kbd>g</kbd> ⇒ <kbd>Space</kbd> | [Cd][mgr.cd] to a directory or [reveal][mgr.reveal] a file via interactive prompt |
 
 [mgr.cd]: /docs/configuration/keymap#mgr.cd

--- a/versioned_docs/version-25.5.31/quick-start.md
+++ b/versioned_docs/version-25.5.31/quick-start.md
@@ -169,8 +169,8 @@ Further navigation commands can be found in the table below.
 | <kbd>J</kbd>                    | Seek down 5 units in the preview                                                  |
 | <kbd>g</kbd> ⇒ <kbd>g</kbd>     | Move cursor to the top                                                            |
 | <kbd>G</kbd>                    | Move cursor to the bottom                                                         |
-| <kbd>z</kbd>                    | [Cd][mgr.cd] to a directory or [reveal][mgr.reveal] a file via fzf                |
-| <kbd>Z</kbd>                    | [Cd][mgr.cd] to a directory via zoxide                                            |
+| <kbd>z</kbd>                    | [Cd][mgr.cd] to a directory via zoxide                                            |
+| <kbd>Z</kbd>                    | [Cd][mgr.cd] to a directory or [reveal][mgr.reveal] a file via fzf                |
 | <kbd>g</kbd> ⇒ <kbd>Space</kbd> | [Cd][mgr.cd] to a directory or [reveal][mgr.reveal] a file via interactive prompt |
 
 [mgr.cd]: /docs/configuration/keymap#mgr.cd


### PR DESCRIPTION
according to #2546

3. Swap the default behavior of the keys z and Z Currently, the default behaviors of z and Z are:

z: Opens zoxide for global directory navigation
Z: Opens fzf in the current working directory

my change applies to both the nightly and the newest stable version of Yazi