### PR TITLE
docs(configuration/theme): add indicator bar

### DIFF
--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -97,22 +97,6 @@ CWD text style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
-### `hovered` {#mgr.hovered}
-
-Hovered file style.
-
-|      |                         |
-| ---- | ----------------------- |
-| Type | [`Style`](#types.style) |
-
-### `preview_hovered` {#mgr.preview_hovered}
-
-Hovered file style, in the preview pane.
-
-|      |                         |
-| ---- | ----------------------- |
-| Type | [`Style`](#types.style) |
-
 ### `find_keyword` {#mgr.find_keyword}
 
 Style of the highlighted portion in the filename.
@@ -210,6 +194,40 @@ For example, `"~/Downloads/Dracula.tmTheme"`, not available after using a flavor
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+## [indicator]
+
+### `parent` {#indicator.parent}
+
+Indicator bar style, in the parent pane.
+
+|      |                         |
+| ---- | ----------------------- |
+| Type | [`Style`](#types.style) |
+
+### `current` {#indicator.current}
+
+Indicator bar style, in the current pane.
+
+|      |                         |
+| ---- | ----------------------- |
+| Type | [`Style`](#types.style) |
+
+### `preview` {#indicator.preview}
+
+Indicator bar style, in the preview pane.
+
+|      |                         |
+| ---- | ----------------------- |
+| Type | [`Style`](#types.style) |
+
+### `padding` {#indicator.padding}
+
+Padding around indicator bar, e.g. `{ open: "[", close: "]" }`.
+
+|      |                                   |
+| ---- | --------------------------------- |
+| Type | `{ open: string, close: string }` |
 
 ## [tabs] {#tabs}
 


### PR DESCRIPTION
Add indicator bar styling in theme configuration page, remove `hovered` and `preview_hovered` under `[mgr]` to chase
https://github.com/sxyazi/yazi/pull/3419.

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
