### PR TITLE
add orphan=true for extract opener to prevent hanging

### DIFF
--- a/docs/dds.md
+++ b/docs/dds.md
@@ -462,7 +462,7 @@ This plugin provides an `extract` event kind for archive extraction, which accep
 # ~/.config/yazi/yazi.toml
 [opener]
 extract = [
-	{ run = "ya pub extract --list %s", desc = "Extract here" },
+	{ run = "ya pub extract --list %s", orphan = true, desc = "Extract here" },
 ]
 ```
 

--- a/versioned_docs/version-26.1.4/dds.md
+++ b/versioned_docs/version-26.1.4/dds.md
@@ -462,7 +462,7 @@ This plugin provides an `extract` event kind for archive extraction, which accep
 # ~/.config/yazi/yazi.toml
 [opener]
 extract = [
-	{ run = "ya pub extract --list %s", desc = "Extract here" },
+	{ run = "ya pub extract --list %s", orphan = true, desc = "Extract here" },
 ]
 ```
 


### PR DESCRIPTION
Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi

## PR body

In https://yazi-rs.github.io/docs/dds/#extract.lua there is a guide on setting up extract as an opener for archive type files, and it uses this opener config:

```toml
extract = [
	{ run = "ya pub extract --list %s", desc = "Extract here" },
]
```
There should also be an `orphan = true` in the options or else the "messaging" process will hang causing a warning on quit saying a process is still running when the extraction has already finished.

I have tested that `orphan = true` will still warn if the extraction hasn't finished, since `orphan` only stops tracking the messaging process of `ya pub extract` and the extraction itself (calling the plugin) will still be tracked.

I added this to both the current version docs and the nightly one since this option will still apply as long as the opener processing logic stays the same.