### PR TITLE
Fix fish shell's shell wrapper for support proper directory history

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -41,7 +41,7 @@ function y
 	set tmp (mktemp -t "yazi-cwd.XXXXXX")
 	command yazi $argv --cwd-file="$tmp"
 	if read -z cwd < "$tmp"; and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
-		builtin cd -- "$cwd"
+		cd -- "$cwd"
 	end
 	rm -f -- "$tmp"
 end


### PR DESCRIPTION
Quote from fish doc, https://fishshell.com/docs/current/cmds/cd.html

> Fish also ships a wrapper function around the builtin cd that understands cd - as changing to the previous directory. See also prevd. This wrapper function maintains a history of the 25 most recently visited directories in the $dirprev and $dirnext global variables. If you make those universal variables your cd history is shared among all fish instances.

`cd` is wrapper function for 'builtin cd' that doesn't manipulate directory history. `builtin cd ` breaks default key binding `alt+left/right` for directory history jump.

```
$ type cd --all --short 
cd is a function (Defined in embedded:functions/cd.fish @ line 5)
cd is a builtin
```

Function `cd` is the default use for user hence, changed `builtin cd` to `cd`.

Thanks.