### PR TITLE
add a link to new plugin "osc7.yazi"

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -189,6 +189,7 @@ Vim:
 
 - [icons-brew.yazi](https://github.com/lpnh/icons-brew.yazi) - Make a hot `theme.toml` for your Yazi icons with your favorite color palette.
 - [lsColorsToToml](https://github.com/Mellbourn/lsColorsToToml) - Generate the color rules for the `[filetype]` section in `theme.toml` based on your `$LS_COLORS`.
+- [osc7.yazi](https://github.com/coder0x6675/osc7.yazi) - Synchronize the terminal's working directory to Yazi.
 
 ## 💖 Add yours {#add-yours}
 


### PR DESCRIPTION
This pull request will add a link to my `osc7.yazi` plugin to the nightly documentation.

Checklist:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
