### PR TITLE
Add relative-path.yazi resource to documentation

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -104,6 +104,7 @@ Clipboard:
 - [wl-clipboard.yazi](https://github.com/grappas/wl-clipboard.yazi) - Wayland implementation of a simple system clipboard.
 - [path-from-root.yazi](https://github.com/aresler/path-from-root.yazi) - Copy file path relative to git root
 - [clippy.yazi](https://github.com/gallardo994/clippy.yazi) - Copy files to clipboard with Clippy on macOS
+- [relative-path.yazi](https://github.com/qwjyh/relative-path.yazi) - Copy file path relative to current working directory.
 
 `filter` enhancements:
 


### PR DESCRIPTION
Added a new resource for copying file paths relative to the current working directory.

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
