### PR TITLE
add autosession.yazi plugin

### DIFF
--- a/versioned_docs/version-26.1.22/resources.md
+++ b/versioned_docs/version-26.1.22/resources.md
@@ -74,6 +74,7 @@ Tabs:
 
 - [projects.yazi](https://github.com/MasouShizuka/projects.yazi) - Save all tabs and their states as a project, and restore them at any time.
 - [close-and-restore-tab.yazi](https://github.com/MasouShizuka/close-and-restore-tab.yazi) - Restore closed tabs.
+- [autosession.yazi](https://github.com/barbanevosa/autosession.yazi) - Automatic session persistence that saves the current state on exit and restores the last saved state on startup.
 
 File actions:
 


### PR DESCRIPTION
add autosession.yazi plugin

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
