### PR TITLE
Clarify reference to built-in commands in vfs.md

### DIFF
--- a/docs/configuration/vfs.md
+++ b/docs/configuration/vfs.md
@@ -33,7 +33,7 @@ Once registered, you can access them by the combination of provider type and nam
 yazi sftp://my-server
 ```
 
-You can also reference them from Yazi's [built-in commands](/docs/configuration/keymap), for example the [`cd`](/docs/configuration/keymap#mgr.cd) command:
+You can also reference them from Yazi's [built-in commands](/docs/configuration/keymap) in `keymap.toml`, for example the [`cd`](/docs/configuration/keymap#mgr.cd) command:
 
 ```toml
 [[mgr.prepend_keymap]]


### PR DESCRIPTION
The documentation references `mgr.*` built-in commands without specifying that they must be defined in `keymap.toml`. This can lead users to place keymap entries in `vfs.toml`, where they are silently ignored. Clarifying this inline helps avoid confusion when configuring VFS services and key bindings.

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [X] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [X] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
