### PR TITLE
Adds missing `symlink_target` to `theme.toml` configuration

### DIFF
--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -113,6 +113,14 @@ Style of current file location in all found files to the right of the filename.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+### `symlink_target` {#mgr.symlink_target}
+
+Style for the path that a symbolic link points to, e.g., the ` -> /path/to/target` part in `my_symbolic_file -> /path/to/target`.
+
+|      |                         |
+| ---- | ----------------------- |
+| Type | [`Style`](#types.style) |
+
 ### `marker_copied` {#mgr.marker_copied}
 
 Copied file marker style.
@@ -194,14 +202,6 @@ For example, `"~/Downloads/Dracula.tmTheme"`, not available after using a flavor
 |      |          |
 | ---- | -------- |
 | Type | `string` |
-
-### symlink_target {#mgr.symlink_target}
-
-Style for the path that a symbolic link points to, e.g., the `-> /path/to/target` part in `my_symbolic_file -> /path/to/target`
-
-| | |
-| ---- | ----------------------- |
-| Type | [`Style`](#types.style) |
 
 ## [indicator]
 

--- a/versioned_docs/version-26.1.22/configuration/theme.md
+++ b/versioned_docs/version-26.1.22/configuration/theme.md
@@ -113,6 +113,14 @@ Style of current file location in all found files to the right of the filename.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+### `symlink_target` {#mgr.symlink_target}
+
+Style for the path that a symbolic link points to, e.g., the ` -> /path/to/target` part in `my_symbolic_file -> /path/to/target`.
+
+|      |                         |
+| ---- | ----------------------- |
+| Type | [`Style`](#types.style) |
+
 ### `marker_copied` {#mgr.marker_copied}
 
 Copied file marker style.
@@ -194,14 +202,6 @@ For example, `"~/Downloads/Dracula.tmTheme"`, not available after using a flavor
 |      |          |
 | ---- | -------- |
 | Type | `string` |
-
-### symlink_target {#mgr.symlink_target}
-
-Style for the path that a symbolic link points to, e.g., the `-> /path/to/target` part in `my_symbolic_file -> /path/to/target`
-
-| | |
-| ---- | ----------------------- |
-| Type | [`Style`](#types.style) |
 
 ## [indicator]
 


### PR DESCRIPTION
## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [ x ] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [ x ] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
