### PR TITLE
docs: use the term "action" instead of "command"

### DIFF
--- a/blog/2023-10-29-why-is-yazi-fast.md
+++ b/blog/2023-10-29-why-is-yazi-fast.md
@@ -89,7 +89,7 @@ The above optimizations are the most noticeable to users, but behind the scenes,
 - The re-implemented highly optimized natural sorting algorithm is [~6 times faster than the `natord`](https://github.com/sxyazi/yazi/pull/237) that `eza` uses in case-insensitive sorting.
 - Yazi caches the directory state that has already been read, avoiding any unnecessary IO operations.
 - When a file in a directory changes, it only updates the changed files rather than re-reading the entire directory list.
-- Merges multiple renders triggered by multiple commands into a single render, avoiding unnecessary CPU consumption.
+- Merges multiple renders triggered by multiple actions into a single render, avoiding unnecessary CPU consumption.
 - Frequent updates to components, such as progress bars, are rendered independently, which is no cost compared to a complete render.
 - The entire plugin system is designed with an asynchronous-first philosophy to avoid blocking the main thread with time-consuming tasks.
 

--- a/docs/configuration/keymap-arrow.md
+++ b/docs/configuration/keymap-arrow.md
@@ -17,4 +17,4 @@ sidebar_class_name: "hidden"
 | `"prev"` | Go to the previous item, or the bottom if the cursor is at the top.                       |
 | `"next"` | Go to the next item, or the top if the cursor is at the bottom.                           |
 
-The `arrow prev`/`arrow next` commands are similar to `arrow -1`/`arrow 1`, except that the former supports wraparound scrolling.
+The `arrow prev`/`arrow next` actions are similar to `arrow -1`/`arrow 1`, except that the former supports wraparound scrolling.

--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -30,11 +30,11 @@ Since Yazi selects the first matching key to run, prepend always has a higher pr
 ```toml
 [mgr]
 prepend_keymap = [
-	{ on = "<C-a>", run = "my-cmd1", desc = "Single command with `Ctrl + a`" },
+	{ on = "<C-a>", run = "act1", desc = "Single action with `Ctrl + a`" },
 ]
 append_keymap = [
-	{ on = [ "g", "b" ], run = "my-cmd2",          desc = "Single command with `g => b`" },
-	{ on = "c",          run = [ "cmd1", "cmd2" ], desc = "Multiple commands with `c`" }
+	{ on = [ "g", "b" ], run = "act2",             desc = "Single action with `g ⇒ b`" },
+	{ on = "c",          run = [ "act1", "act2" ], desc = "Multiple actions with `c`" }
 ]
 ```
 
@@ -43,18 +43,18 @@ Or in another different style:
 ```toml
 [[mgr.prepend_keymap]]
 on   = "<C-a>"
-run  = "my-cmd1"
-desc = "Single command with `Ctrl + a`"
+run  = "act1"
+desc = "Single action with `Ctrl + a`"
 
 [[mgr.append_keymap]]
 on  = [ "g", "b" ]
-run = "my-cmd2"
-desc = "Single command with `g => b`"
+run = "act2"
+desc = "Single action with `g ⇒ b`"
 
 [[mgr.append_keymap]]
 on  = "c"
-run = [ "my-cmd1", "my-cmd2" ]
-desc = "Multiple commands with `c`"
+run = [ "act1", "act2" ]
+desc = "Multiple actions with `c`"
 ```
 
 But keep in mind that you can only choose one of them, and it cannot be a combination of the two, as TOML language does not allow this:
@@ -62,12 +62,12 @@ But keep in mind that you can only choose one of them, and it cannot be a combin
 ```toml
 [mgr]
 prepend_keymap = [
-	{ on = "<C-a>", run = "my-cmd1" },
+	{ on = "<C-a>", run = "act1" },
 ]
 
 [[mgr.append_keymap]]
 on  = [ "g", "b" ]
-run = "my-cmd2"
+run = "act2"
 ```
 
 When you don't need any default and want to fully customize your keybindings, use `keymap`, for example:
@@ -76,8 +76,8 @@ When you don't need any default and want to fully customize your keybindings, us
 [mgr]
 keymap = [
 	# This will override all default keybindings, and just keep the two below.
-	{ on = "<C-a>",      run = "my-cmd1" },
-	{ on = [ "g", "b" ], run = "my-cmd2" },
+	{ on = "<C-a>",      run = "act1" },
+	{ on = [ "g", "b" ], run = "act2" },
 ]
 ```
 
@@ -217,7 +217,7 @@ run  = "cd ~/Pictures"
 desc = "Cd to ~/Pictures"
 ```
 
-For Windows users, you can also switch drives using the `cd` command:
+For Windows users, you can also switch drives using the `cd` action:
 
 ```toml
 [[mgr.prepend_keymap]]
@@ -469,7 +469,7 @@ You can search with an empty keyword (`""`) via `fd` to achieve flat view.
 	<video src="https://github.com/sxyazi/yazi/assets/17523360/d2c9df9b-b7ef-41ec-889f-26b2f1117cd0" width="100%" controls muted></video>
 </details>
 
-Or bind a key to the `search_do` command to quickly switch to the flat view:
+Or bind a key to the `search_do` action to quickly switch to the flat view:
 
 ```toml
 [[mgr.prepend_keymap]]
@@ -537,7 +537,7 @@ If neither `[url]` nor `--current` is specified, will use the startup directory 
 | --------------- | ----------------------------------------------- |
 | `[n]`           | Close the tab at position `n`, starting from 0. |
 
-If you want to close the current tab, use the [`close`](/docs/configuration/keymap/#mgr.close) command instead.
+If you want to close the current tab, use the [`close`](/docs/configuration/keymap/#mgr.close) action instead.
 
 ### `tab_switch` {#mgr.tab_switch}
 
@@ -562,7 +562,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#mgr.noop}
 
-If you want to disable certain preset keybindings without rewriting the entire `keymap`, you can use the virtual `noop` command.
+If you want to disable certain preset keybindings without rewriting the entire `keymap`, you can use the virtual `noop` action.
 
 For example, to disable the default keybinding of <kbd>g</kbd> ⇒ <kbd>c</kbd>, use:
 
@@ -620,7 +620,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#tasks.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [spot] {#spot}
 
@@ -652,7 +652,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#spot.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ### `help` {#spot.help}
 
@@ -682,7 +682,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#pick.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [input] {#input}
 
@@ -721,7 +721,7 @@ Move forward to the start of the next word.
 
 ### `insert` {#input.insert}
 
-Enter insert mode. This command is only available in normal mode.
+Enter insert mode. This action is only available in normal mode.
 
 | Argument/Option | Description              |
 | --------------- | ------------------------ |
@@ -729,11 +729,11 @@ Enter insert mode. This command is only available in normal mode.
 
 ### `visual` {#input.visual}
 
-Enter visual mode. This command is only available in normal mode.
+Enter visual mode. This action is only available in normal mode.
 
 ### `delete` {#input.delete}
 
-Delete the selected characters. This command is only available in normal mode.
+Delete the selected characters. This action is only available in normal mode.
 
 | Argument/Option | Description                                                                |
 | --------------- | -------------------------------------------------------------------------- |
@@ -742,11 +742,11 @@ Delete the selected characters. This command is only available in normal mode.
 
 ### `yank` {#input.yank}
 
-Copy the selected characters. This command is only available in normal mode.
+Copy the selected characters. This action is only available in normal mode.
 
 ### `paste` {#input.paste}
 
-Paste the copied characters after the cursor. This command is only available in normal mode.
+Paste the copied characters after the cursor. This action is only available in normal mode.
 
 | Argument/Option | Description                                    |
 | --------------- | ---------------------------------------------- |
@@ -754,19 +754,19 @@ Paste the copied characters after the cursor. This command is only available in 
 
 ### `undo` {#input.undo}
 
-Undo the last operation. This command is only available in normal mode.
+Undo the last operation. This action is only available in normal mode.
 
 ### `redo` {#input.redo}
 
-Redo the last operation. This command is only available in normal mode.
+Redo the last operation. This action is only available in normal mode.
 
 ### `help` {#input.help}
 
-Open the help menu. This command is only available in normal mode.
+Open the help menu. This action is only available in normal mode.
 
 ### `backspace` {#input.backspace}
 
-Delete the character before the cursor. This command is only available in insert mode.
+Delete the character before the cursor. This action is only available in insert mode.
 
 | Argument/Option | Description                            |
 | --------------- | -------------------------------------- |
@@ -774,7 +774,7 @@ Delete the character before the cursor. This command is only available in insert
 
 ### `kill` {#input.kill}
 
-Kill the specified range of characters. This command is only available in insert mode.
+Kill the specified range of characters. This action is only available in insert mode.
 
 | Argument/Option | Description                                      |
 | --------------- | ------------------------------------------------ |
@@ -785,11 +785,11 @@ Kill the specified range of characters. This command is only available in insert
 
 ### `plugin` {#input.plugin}
 
-See [Functional plugin](/docs/plugins/overview#functional-plugin). This command is only available in normal mode.
+See [Functional plugin](/docs/plugins/overview#functional-plugin). This action is only available in normal mode.
 
 ### `noop` {#input.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [confirm] {#confirm}
 
@@ -833,7 +833,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#cmp.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [help] {#help}
 
@@ -859,4 +859,4 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#help.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).

--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -752,7 +752,7 @@ Key column style.
 
 ### `run` {#help.run}
 
-Command column style.
+Action column style.
 
 |      |                         |
 | ---- | ----------------------- |

--- a/docs/configuration/vfs.md
+++ b/docs/configuration/vfs.md
@@ -33,7 +33,7 @@ Once registered, you can access them by the combination of provider type and nam
 yazi sftp://my-server
 ```
 
-You can also reference them from Yazi's [built-in commands](/docs/configuration/keymap) in `keymap.toml`, for example the [`cd`](/docs/configuration/keymap#mgr.cd) command:
+You can also reference them from Yazi's [built-in actions](/docs/configuration/keymap) in `keymap.toml`, for example the [`cd`](/docs/configuration/keymap#mgr.cd) action:
 
 ```toml
 [[mgr.prepend_keymap]]
@@ -42,7 +42,7 @@ run  = "cd sftp://my-server"
 desc = "Go to my-server"
 ```
 
-Or the [`reveal`](/docs/configuration/keymap#mgr.reveal) command:
+Or the [`reveal`](/docs/configuration/keymap#mgr.reveal) action:
 
 ```toml
 [[mgr.prepend_keymap]]

--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -441,7 +441,7 @@ Some inputs have special placeholders that will be replaced with actual content 
 
 - create_title: [String, String]
 
-  It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` command.
+  It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` action.
 
 - rename_title: String
 

--- a/docs/dds.md
+++ b/docs/dds.md
@@ -24,7 +24,7 @@ The DDS has three usage:
 
 - [Plugin API](/docs/plugins/utils#ps): Using Lua-based publish-subscribe model as the message carrier.
 - [`ya pub` and `ya pub-to`](#ya-pub): Using [`ya` CLI tool](/docs/cli) as the message carrier.
-- [`ya emit` and `ya emit-to`](#ya-emit): Using [`ya` CLI tool](/docs/cli) as the command carrier.
+- [`ya emit` and `ya emit-to`](#ya-emit): Using [`ya` CLI tool](/docs/cli) as the action carrier.
 - [Real-time `stdout` reporting](#stdout-reporting): Using `stdout` as the carrier.
 
 ### `ya pub` and `ya pub-to` {#ya-pub}
@@ -67,12 +67,12 @@ For greater convenience in integrating within the command-line environment, they
 
 ### `ya emit` and `ya emit-to` {#ya-emit}
 
-If you're in a Yazi subshell where the `$YAZI_ID` environment variable is set, you can use `ya emit` to send a command to the current instance for execution.
+If you're in a Yazi subshell where the `$YAZI_ID` environment variable is set, you can use `ya emit` to send an action to the current instance for execution.
 
-The command format is the same as what you'd write in the [`keymap.toml`](/docs/configuration/keymap):
+The action format is the same as what you'd write in the [`keymap.toml`](/docs/configuration/keymap):
 
 ```sh
-ya emit <command> <args>
+ya emit <action> <args>
 ```
 
 For example:
@@ -82,10 +82,10 @@ ya emit cd /tmp
 ya emit reveal /tmp/foo
 ```
 
-You can also send commands to a specific remote instance using `ya emit-to`:
+You can also send actions to a specific remote instance using `ya emit-to`:
 
 ```sh
-ya emit-to <receiver> <command> <args>
+ya emit-to <receiver> <action> <args>
 ```
 
 For example:
@@ -401,7 +401,7 @@ System reserves kind.
 
 ### `dds.lua` {#dds.lua}
 
-This plugin provides a `dds-emit` event kind, which is used for the implementation of the `ya emit` subcommand — `ya emit` is a shorthand for `ya pub`, and the emitted command will be converted into an equivalent `ya pub` event message.
+This plugin provides a `dds-emit` event kind, which is used for the implementation of the `ya emit` subcommand — `ya emit` is a shorthand for `ya pub`, and the emitted action will be converted into an equivalent `ya pub` event message.
 
 With `ya emit`, you can implement many interesting features, such as synchronizing the CWD of the current Yazi instance when exiting from a subshell:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,9 +30,9 @@ Unfortunately, this cannot cater to all users, and even the colors needed by the
 
 So, please [use a Yazi flavor](https://github.com/yazi-rs/flavors) that matches your terminal theme. Of course, if you find a color that better covers most terminals, feel free to create a PR!
 
-## Why can't "Open" and "Enter" be a single command? {#why-separate-open-enter}
+## Why can't "Open" and "Enter" be a single action? {#why-separate-open-enter}
 
-The decision to separate `enter` and `open` commands was intentional.
+The decision to separate `enter` and `open` actions was intentional.
 
 Yazi will be adding the ability to treat an archive as a directory in the future, allowing direct operations on the files inside.
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -43,12 +43,12 @@ Where:
 
 A plugin has two usages:
 
-- [Functional plugin](#functional-plugin): Bind the `plugin` command to a key in `keymap.toml`, and activate it by pressing the key.
+- [Functional plugin](#functional-plugin): Bind the `plugin` action to a key in `keymap.toml`, and activate it by pressing the key.
 - [Custom previewers, preloaders](/docs/configuration/yazi#plugin): Configure them as previewers or preloaders under `[plugin]` of your `yazi.toml`.
 
 ### Functional plugin {#functional-plugin}
 
-You can bind a `plugin` command to a specific key in your `keymap.toml` with:
+You can bind a `plugin` action to a specific key in your `keymap.toml` with:
 
 | Argument/Option | Description                                           |
 | --------------- | ----------------------------------------------------- |

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -28,22 +28,22 @@ If the file is not allowed to be cached, such as it's ignored in the user config
 | `opts` | `{ file: File, skip: integer }` |
 | Return | `Url?`                          |
 
-### `emit(cmd, args)` {#ya.emit}
+### `emit(action, args)` {#ya.emit}
 
-Send a command to the [`[mgr]`](/docs/configuration/keymap#mgr) without waiting for the executor to execute:
+Send an action to the [`[mgr]`](/docs/configuration/keymap#mgr) without waiting for the executor to execute:
 
 ```lua
-ya.emit("my-cmd", { "hello", 123, foo = true, bar_baz = "world" })
+ya.emit("action", { "hello", 123, foo = true, bar_baz = "world" })
 
 -- Equivalent to:
--- my-cmd "hello" "123" --foo --bar-baz="world"
+-- action "hello" "123" --foo --bar-baz="world"
 ```
 
-| In/Out | Type                              | Note                                                                                    |
-| ------ | --------------------------------- | --------------------------------------------------------------------------------------- |
-| `cmd`  | `string`                          | -                                                                                       |
-| `args` | `{ [integer\|string]: Sendable }` | Table values are [Sendable][sendable] that follow [Ownership transfer rules][ownership] |
-| Return | `unknown`                         | -                                                                                       |
+| In/Out   | Type                              | Note                                                                                    |
+| -------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| `action` | `string`                          | -                                                                                       |
+| `args`   | `{ [integer\|string]: Sendable }` | Table values are [Sendable][sendable] that follow [Ownership transfer rules][ownership] |
+| Return   | `unknown`                         | -                                                                                       |
 
 ### `image_show(url, rect)` {#ya.image_show}
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -176,7 +176,7 @@ or Vim-like keys such as <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd>, <kbd>l</kbd>:
 | <kbd>l</kbd> | <kbd>→</kbd>  | Enter hovered directory                         |
 | <kbd>h</kbd> | <kbd>←</kbd>  | Leave the current directory and into its parent |
 
-Further navigation commands can be found in the table below.
+Further navigation actions can be found in the table below.
 
 | Key binding                     | Action                                                                            |
 | ------------------------------- | --------------------------------------------------------------------------------- |
@@ -193,7 +193,7 @@ Further navigation commands can be found in the table below.
 
 ### Selection
 
-To select files and directories, the following commands are available.
+To select files and directories, the following actions are available.
 
 | Key binding                    | Action                                     |
 | ------------------------------ | ------------------------------------------ |
@@ -206,7 +206,7 @@ To select files and directories, the following commands are available.
 
 ### File operations
 
-To interact with selected files/directories use any of the commands below.
+To interact with selected files/directories use any of the actions below.
 
 | Key binding                         | Action                                                                  |
 | ----------------------------------- | ----------------------------------------------------------------------- |
@@ -226,7 +226,7 @@ To interact with selected files/directories use any of the commands below.
 | <kbd>r</kbd>                        | Rename selected file(s)                                                 |
 | <kbd>.</kbd>                        | Toggle the visibility of hidden files                                   |
 
-Further file operation commands can be found in the table below.
+Further file operation actions can be found in the table below.
 
 | Key binding                    | Action                                     |
 | ------------------------------ | ------------------------------------------ |
@@ -238,7 +238,7 @@ Further file operation commands can be found in the table below.
 
 ### Copy paths
 
-To copy paths, use any of the following commands below.
+To copy paths, use any of the following actions below.
 
 _Observation: <kbd>c</kbd> ⇒ <kbd>d</kbd> indicates pressing the <kbd>c</kbd> key followed by pressing the <kbd>d</kbd> key._
 
@@ -274,7 +274,7 @@ _Observation: <kbd>c</kbd> ⇒ <kbd>d</kbd> indicates pressing the <kbd>c</kbd> 
 
 ### Sorting
 
-To sort files/directories use the following commands.
+To sort files/directories use the following actions.
 
 _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> key followed by pressing the <kbd>a</kbd> key._
 
@@ -298,7 +298,7 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 
 | Key binding                                   | Action                             |
 | --------------------------------------------- | ---------------------------------- |
-| <kbd>t</kbd>                                  | Create a new tab with CWD          |
+| <kbd>t</kbd> ⇒ <kbd>t</kbd>                   | Create a new tab in CWD            |
 | <kbd>1</kbd>, <kbd>2</kbd>, ..., <kbd>9</kbd> | Switch to the N-th tab             |
 | <kbd>[</kbd>                                  | Switch to the previous tab         |
 | <kbd>]</kbd>                                  | Switch to the next tab             |

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -132,9 +132,9 @@ Clipboard:
 
 - [smart-paste.yazi](https://github.com/yazi-rs/plugins/tree/main/smart-paste.yazi) - Paste files into the hovered directory or to the CWD if hovering over a file.
 
-General command enhancements:
+General action enhancements:
 
-- [augment-command.yazi](https://github.com/hankertrix/augment-command.yazi) - Enhances a few Yazi commands with better handling of the choice between selected items and the hovered item.
+- [augment-command.yazi](https://github.com/hankertrix/augment-command.yazi) - Enhances a few Yazi actions with better handling of the choice between selected items and the hovered item.
 
 UI enhancements:
 
@@ -186,7 +186,7 @@ Vim:
 
 - [yazi-prompt.sh](https://github.com/Sonico98/yazi-prompt.sh) - Display an indicator in your prompt when running inside a yazi subshell.
 - [custom-shell.yazi](https://github.com/AnirudhG07/custom-shell.yazi) - Run any commands through your default system shell.
-- [command.yazi](https://github.com/KKV9/command.yazi) - Display a prompt for executing yazi commands.
+- [command.yazi](https://github.com/KKV9/command.yazi) - Display a prompt for executing yazi actions.
 
 ## 🛠️ Utilities {#utilities}
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -40,7 +40,7 @@ desc = "Open PowerShell here"
 
 ## Close input by once <kbd>Esc</kbd> press {#close-input-by-esc}
 
-You can change the <kbd>Esc</kbd> of input component from the default `escape` to `close` command, in your `keymap.toml`:
+You can change the <kbd>Esc</kbd> of input component from the default `escape` to `close` action, in your `keymap.toml`:
 
 ```toml
 [[input.prepend_keymap]]
@@ -77,7 +77,7 @@ Then bind it to the <kbd>t</kbd> key, in your `keymap.toml`:
 
 ```toml
 [[mgr.prepend_keymap]]
-on   = "t"
+on   = [ "t", "t" ]
 run  = "plugin smart-tab"
 desc = "Create a tab and enter the hovered directory"
 ```
@@ -225,7 +225,7 @@ The above example is for Hyprland + Hyprpaper, adapt to the command of your resp
 
 ## Linux: Copy selected files to the system clipboard while yanking {#selected-files-to-clipboard}
 
-Yazi allows multiple commands to be bound to a single key, so you can set <kbd>y</kbd> to not only do the `yank` but also run a shell script:
+Yazi allows multiple actions to be bound to a single key, so you can set <kbd>y</kbd> to not only do the `yank` but also run a shell script:
 
 ```toml
 [[mgr.prepend_keymap]]

--- a/versioned_docs/version-26.1.22/configuration/keymap-arrow.md
+++ b/versioned_docs/version-26.1.22/configuration/keymap-arrow.md
@@ -17,4 +17,4 @@ sidebar_class_name: "hidden"
 | `"prev"` | Go to the previous item, or the bottom if the cursor is at the top.                       |
 | `"next"` | Go to the next item, or the top if the cursor is at the bottom.                           |
 
-The `arrow prev`/`arrow next` commands are similar to `arrow -1`/`arrow 1`, except that the former supports wraparound scrolling.
+The `arrow prev`/`arrow next` actions are similar to `arrow -1`/`arrow 1`, except that the former supports wraparound scrolling.

--- a/versioned_docs/version-26.1.22/configuration/keymap.md
+++ b/versioned_docs/version-26.1.22/configuration/keymap.md
@@ -30,11 +30,11 @@ Since Yazi selects the first matching key to run, prepend always has a higher pr
 ```toml
 [mgr]
 prepend_keymap = [
-	{ on = "<C-a>", run = "my-cmd1", desc = "Single command with `Ctrl + a`" },
+	{ on = "<C-a>", run = "act1", desc = "Single action with `Ctrl + a`" },
 ]
 append_keymap = [
-	{ on = [ "g", "b" ], run = "my-cmd2",          desc = "Single command with `g => b`" },
-	{ on = "c",          run = [ "cmd1", "cmd2" ], desc = "Multiple commands with `c`" }
+	{ on = [ "g", "b" ], run = "act2",             desc = "Single action with `g ⇒ b`" },
+	{ on = "c",          run = [ "act1", "act2" ], desc = "Multiple actions with `c`" }
 ]
 ```
 
@@ -43,18 +43,18 @@ Or in another different style:
 ```toml
 [[mgr.prepend_keymap]]
 on   = "<C-a>"
-run  = "my-cmd1"
-desc = "Single command with `Ctrl + a`"
+run  = "act1"
+desc = "Single action with `Ctrl + a`"
 
 [[mgr.append_keymap]]
 on  = [ "g", "b" ]
-run = "my-cmd2"
-desc = "Single command with `g => b`"
+run = "act2"
+desc = "Single action with `g ⇒ b`"
 
 [[mgr.append_keymap]]
 on  = "c"
-run = [ "my-cmd1", "my-cmd2" ]
-desc = "Multiple commands with `c`"
+run = [ "act1", "act2" ]
+desc = "Multiple actions with `c`"
 ```
 
 But keep in mind that you can only choose one of them, and it cannot be a combination of the two, as TOML language does not allow this:
@@ -62,12 +62,12 @@ But keep in mind that you can only choose one of them, and it cannot be a combin
 ```toml
 [mgr]
 prepend_keymap = [
-	{ on = "<C-a>", run = "my-cmd1" },
+	{ on = "<C-a>", run = "act1" },
 ]
 
 [[mgr.append_keymap]]
 on  = [ "g", "b" ]
-run = "my-cmd2"
+run = "act2"
 ```
 
 When you don't need any default and want to fully customize your keybindings, use `keymap`, for example:
@@ -76,8 +76,8 @@ When you don't need any default and want to fully customize your keybindings, us
 [mgr]
 keymap = [
 	# This will override all default keybindings, and just keep the two below.
-	{ on = "<C-a>",      run = "my-cmd1" },
-	{ on = [ "g", "b" ], run = "my-cmd2" },
+	{ on = "<C-a>",      run = "act1" },
+	{ on = [ "g", "b" ], run = "act2" },
 ]
 ```
 
@@ -217,7 +217,7 @@ run  = "cd ~/Pictures"
 desc = "Cd to ~/Pictures"
 ```
 
-For Windows users, you can also switch drives using the `cd` command:
+For Windows users, you can also switch drives using the `cd` action:
 
 ```toml
 [[mgr.prepend_keymap]]
@@ -469,7 +469,7 @@ You can search with an empty keyword (`""`) via `fd` to achieve flat view.
 	<video src="https://github.com/sxyazi/yazi/assets/17523360/d2c9df9b-b7ef-41ec-889f-26b2f1117cd0" width="100%" controls muted></video>
 </details>
 
-Or bind a key to the `search_do` command to quickly switch to the flat view:
+Or bind a key to the `search_do` action to quickly switch to the flat view:
 
 ```toml
 [[mgr.prepend_keymap]]
@@ -537,7 +537,7 @@ If neither `[url]` nor `--current` is specified, will use the startup directory 
 | --------------- | ----------------------------------------------- |
 | `[n]`           | Close the tab at position `n`, starting from 0. |
 
-If you want to close the current tab, use the [`close`](/docs/configuration/keymap/#mgr.close) command instead.
+If you want to close the current tab, use the [`close`](/docs/configuration/keymap/#mgr.close) action instead.
 
 ### `tab_switch` {#mgr.tab_switch}
 
@@ -562,7 +562,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#mgr.noop}
 
-If you want to disable certain preset keybindings without rewriting the entire `keymap`, you can use the virtual `noop` command.
+If you want to disable certain preset keybindings without rewriting the entire `keymap`, you can use the virtual `noop` action.
 
 For example, to disable the default keybinding of <kbd>g</kbd> ⇒ <kbd>c</kbd>, use:
 
@@ -620,7 +620,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#tasks.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [spot] {#spot}
 
@@ -652,7 +652,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#spot.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ### `help` {#spot.help}
 
@@ -682,7 +682,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#pick.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [input] {#input}
 
@@ -721,7 +721,7 @@ Move forward to the start of the next word.
 
 ### `insert` {#input.insert}
 
-Enter insert mode. This command is only available in normal mode.
+Enter insert mode. This action is only available in normal mode.
 
 | Argument/Option | Description              |
 | --------------- | ------------------------ |
@@ -729,11 +729,11 @@ Enter insert mode. This command is only available in normal mode.
 
 ### `visual` {#input.visual}
 
-Enter visual mode. This command is only available in normal mode.
+Enter visual mode. This action is only available in normal mode.
 
 ### `delete` {#input.delete}
 
-Delete the selected characters. This command is only available in normal mode.
+Delete the selected characters. This action is only available in normal mode.
 
 | Argument/Option | Description                                                                |
 | --------------- | -------------------------------------------------------------------------- |
@@ -742,11 +742,11 @@ Delete the selected characters. This command is only available in normal mode.
 
 ### `yank` {#input.yank}
 
-Copy the selected characters. This command is only available in normal mode.
+Copy the selected characters. This action is only available in normal mode.
 
 ### `paste` {#input.paste}
 
-Paste the copied characters after the cursor. This command is only available in normal mode.
+Paste the copied characters after the cursor. This action is only available in normal mode.
 
 | Argument/Option | Description                                    |
 | --------------- | ---------------------------------------------- |
@@ -754,19 +754,19 @@ Paste the copied characters after the cursor. This command is only available in 
 
 ### `undo` {#input.undo}
 
-Undo the last operation. This command is only available in normal mode.
+Undo the last operation. This action is only available in normal mode.
 
 ### `redo` {#input.redo}
 
-Redo the last operation. This command is only available in normal mode.
+Redo the last operation. This action is only available in normal mode.
 
 ### `help` {#input.help}
 
-Open the help menu. This command is only available in normal mode.
+Open the help menu. This action is only available in normal mode.
 
 ### `backspace` {#input.backspace}
 
-Delete the character before the cursor. This command is only available in insert mode.
+Delete the character before the cursor. This action is only available in insert mode.
 
 | Argument/Option | Description                            |
 | --------------- | -------------------------------------- |
@@ -774,7 +774,7 @@ Delete the character before the cursor. This command is only available in insert
 
 ### `kill` {#input.kill}
 
-Kill the specified range of characters. This command is only available in insert mode.
+Kill the specified range of characters. This action is only available in insert mode.
 
 | Argument/Option | Description                                      |
 | --------------- | ------------------------------------------------ |
@@ -785,11 +785,11 @@ Kill the specified range of characters. This command is only available in insert
 
 ### `plugin` {#input.plugin}
 
-See [Functional plugin](/docs/plugins/overview#functional-plugin). This command is only available in normal mode.
+See [Functional plugin](/docs/plugins/overview#functional-plugin). This action is only available in normal mode.
 
 ### `noop` {#input.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [confirm] {#confirm}
 
@@ -833,7 +833,7 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#cmp.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).
 
 ## [help] {#help}
 
@@ -859,4 +859,4 @@ See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
 ### `noop` {#help.noop}
 
-See [`noop` command](#mgr.noop).
+See [`noop` action](#mgr.noop).

--- a/versioned_docs/version-26.1.22/configuration/theme.md
+++ b/versioned_docs/version-26.1.22/configuration/theme.md
@@ -752,7 +752,7 @@ Key column style.
 
 ### `run` {#help.run}
 
-Command column style.
+Action column style.
 
 |      |                         |
 | ---- | ----------------------- |

--- a/versioned_docs/version-26.1.22/configuration/vfs.md
+++ b/versioned_docs/version-26.1.22/configuration/vfs.md
@@ -33,7 +33,7 @@ Once registered, you can access them by the combination of provider type and nam
 yazi sftp://my-server
 ```
 
-You can also reference them from Yazi's [built-in commands](/docs/configuration/keymap), for example the [`cd`](/docs/configuration/keymap#mgr.cd) command:
+You can also reference them from Yazi's [built-in actions](/docs/configuration/keymap) in `keymap.toml`, for example the [`cd`](/docs/configuration/keymap#mgr.cd) action:
 
 ```toml
 [[mgr.prepend_keymap]]
@@ -42,7 +42,7 @@ run  = "cd sftp://my-server"
 desc = "Go to my-server"
 ```
 
-Or the [`reveal`](/docs/configuration/keymap#mgr.reveal) command:
+Or the [`reveal`](/docs/configuration/keymap#mgr.reveal) action:
 
 ```toml
 [[mgr.prepend_keymap]]

--- a/versioned_docs/version-26.1.22/configuration/yazi.md
+++ b/versioned_docs/version-26.1.22/configuration/yazi.md
@@ -441,7 +441,7 @@ Some inputs have special placeholders that will be replaced with actual content 
 
 - create_title: [String, String]
 
-  It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` command.
+  It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` action.
 
 - rename_title: String
 

--- a/versioned_docs/version-26.1.22/dds.md
+++ b/versioned_docs/version-26.1.22/dds.md
@@ -24,7 +24,7 @@ The DDS has three usage:
 
 - [Plugin API](/docs/plugins/utils#ps): Using Lua-based publish-subscribe model as the message carrier.
 - [`ya pub` and `ya pub-to`](#ya-pub): Using [`ya` CLI tool](/docs/cli) as the message carrier.
-- [`ya emit` and `ya emit-to`](#ya-emit): Using [`ya` CLI tool](/docs/cli) as the command carrier.
+- [`ya emit` and `ya emit-to`](#ya-emit): Using [`ya` CLI tool](/docs/cli) as the action carrier.
 - [Real-time `stdout` reporting](#stdout-reporting): Using `stdout` as the carrier.
 
 ### `ya pub` and `ya pub-to` {#ya-pub}
@@ -67,12 +67,12 @@ For greater convenience in integrating within the command-line environment, they
 
 ### `ya emit` and `ya emit-to` {#ya-emit}
 
-If you're in a Yazi subshell where the `$YAZI_ID` environment variable is set, you can use `ya emit` to send a command to the current instance for execution.
+If you're in a Yazi subshell where the `$YAZI_ID` environment variable is set, you can use `ya emit` to send an action to the current instance for execution.
 
-The command format is the same as what you'd write in the [`keymap.toml`](/docs/configuration/keymap):
+The action format is the same as what you'd write in the [`keymap.toml`](/docs/configuration/keymap):
 
 ```sh
-ya emit <command> <args>
+ya emit <action> <args>
 ```
 
 For example:
@@ -82,10 +82,10 @@ ya emit cd /tmp
 ya emit reveal /tmp/foo
 ```
 
-You can also send commands to a specific remote instance using `ya emit-to`:
+You can also send actions to a specific remote instance using `ya emit-to`:
 
 ```sh
-ya emit-to <receiver> <command> <args>
+ya emit-to <receiver> <action> <args>
 ```
 
 For example:
@@ -401,7 +401,7 @@ System reserves kind.
 
 ### `dds.lua` {#dds.lua}
 
-This plugin provides a `dds-emit` event kind, which is used for the implementation of the `ya emit` subcommand — `ya emit` is a shorthand for `ya pub`, and the emitted command will be converted into an equivalent `ya pub` event message.
+This plugin provides a `dds-emit` event kind, which is used for the implementation of the `ya emit` subcommand — `ya emit` is a shorthand for `ya pub`, and the emitted action will be converted into an equivalent `ya pub` event message.
 
 With `ya emit`, you can implement many interesting features, such as synchronizing the CWD of the current Yazi instance when exiting from a subshell:
 

--- a/versioned_docs/version-26.1.22/faq.md
+++ b/versioned_docs/version-26.1.22/faq.md
@@ -30,9 +30,9 @@ Unfortunately, this cannot cater to all users, and even the colors needed by the
 
 So, please [use a Yazi flavor](https://github.com/yazi-rs/flavors) that matches your terminal theme. Of course, if you find a color that better covers most terminals, feel free to create a PR!
 
-## Why can't "Open" and "Enter" be a single command? {#why-separate-open-enter}
+## Why can't "Open" and "Enter" be a single action? {#why-separate-open-enter}
 
-The decision to separate `enter` and `open` commands was intentional.
+The decision to separate `enter` and `open` actions was intentional.
 
 Yazi will be adding the ability to treat an archive as a directory in the future, allowing direct operations on the files inside.
 

--- a/versioned_docs/version-26.1.22/plugins/overview.md
+++ b/versioned_docs/version-26.1.22/plugins/overview.md
@@ -43,12 +43,12 @@ Where:
 
 A plugin has two usages:
 
-- [Functional plugin](#functional-plugin): Bind the `plugin` command to a key in `keymap.toml`, and activate it by pressing the key.
+- [Functional plugin](#functional-plugin): Bind the `plugin` action to a key in `keymap.toml`, and activate it by pressing the key.
 - [Custom previewers, preloaders](/docs/configuration/yazi#plugin): Configure them as previewers or preloaders under `[plugin]` of your `yazi.toml`.
 
 ### Functional plugin {#functional-plugin}
 
-You can bind a `plugin` command to a specific key in your `keymap.toml` with:
+You can bind a `plugin` action to a specific key in your `keymap.toml` with:
 
 | Argument/Option | Description                                           |
 | --------------- | ----------------------------------------------------- |

--- a/versioned_docs/version-26.1.22/plugins/utils.md
+++ b/versioned_docs/version-26.1.22/plugins/utils.md
@@ -28,22 +28,22 @@ If the file is not allowed to be cached, such as it's ignored in the user config
 | `opts` | `{ file: File, skip: integer }` |
 | Return | `Url?`                          |
 
-### `emit(cmd, args)` {#ya.emit}
+### `emit(action, args)` {#ya.emit}
 
-Send a command to the [`[mgr]`](/docs/configuration/keymap#mgr) without waiting for the executor to execute:
+Send an action to the [`[mgr]`](/docs/configuration/keymap#mgr) without waiting for the executor to execute:
 
 ```lua
-ya.emit("my-cmd", { "hello", 123, foo = true, bar_baz = "world" })
+ya.emit("action", { "hello", 123, foo = true, bar_baz = "world" })
 
 -- Equivalent to:
--- my-cmd "hello" "123" --foo --bar-baz="world"
+-- action "hello" "123" --foo --bar-baz="world"
 ```
 
-| In/Out | Type                              | Note                                                                                    |
-| ------ | --------------------------------- | --------------------------------------------------------------------------------------- |
-| `cmd`  | `string`                          | -                                                                                       |
-| `args` | `{ [integer\|string]: Sendable }` | Table values are [Sendable][sendable] that follow [Ownership transfer rules][ownership] |
-| Return | `unknown`                         | -                                                                                       |
+| In/Out   | Type                              | Note                                                                                    |
+| -------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| `action` | `string`                          | -                                                                                       |
+| `args`   | `{ [integer\|string]: Sendable }` | Table values are [Sendable][sendable] that follow [Ownership transfer rules][ownership] |
+| Return   | `unknown`                         | -                                                                                       |
 
 ### `image_show(url, rect)` {#ya.image_show}
 

--- a/versioned_docs/version-26.1.22/resources.md
+++ b/versioned_docs/version-26.1.22/resources.md
@@ -131,9 +131,9 @@ Clipboard:
 
 - [smart-paste.yazi](https://github.com/yazi-rs/plugins/tree/main/smart-paste.yazi) - Paste files into the hovered directory or to the CWD if hovering over a file.
 
-General command enhancements:
+General action enhancements:
 
-- [augment-command.yazi](https://github.com/hankertrix/augment-command.yazi) - Enhances a few Yazi commands with better handling of the choice between selected items and the hovered item.
+- [augment-command.yazi](https://github.com/hankertrix/augment-command.yazi) - Enhances a few Yazi actions with better handling of the choice between selected items and the hovered item.
 
 UI enhancements:
 
@@ -185,7 +185,7 @@ Vim:
 
 - [yazi-prompt.sh](https://github.com/Sonico98/yazi-prompt.sh) - Display an indicator in your prompt when running inside a yazi subshell.
 - [custom-shell.yazi](https://github.com/AnirudhG07/custom-shell.yazi) - Run any commands through your default system shell.
-- [command.yazi](https://github.com/KKV9/command.yazi) - Display a prompt for executing yazi commands.
+- [command.yazi](https://github.com/KKV9/command.yazi) - Display a prompt for executing yazi actions.
 
 ## 🛠️ Utilities {#utilities}
 

--- a/versioned_docs/version-26.1.22/tips.md
+++ b/versioned_docs/version-26.1.22/tips.md
@@ -40,7 +40,7 @@ desc = "Open PowerShell here"
 
 ## Close input by once <kbd>Esc</kbd> press {#close-input-by-esc}
 
-You can change the <kbd>Esc</kbd> of input component from the default `escape` to `close` command, in your `keymap.toml`:
+You can change the <kbd>Esc</kbd> of input component from the default `escape` to `close` action, in your `keymap.toml`:
 
 ```toml
 [[input.prepend_keymap]]
@@ -77,7 +77,7 @@ Then bind it to the <kbd>t</kbd> key, in your `keymap.toml`:
 
 ```toml
 [[mgr.prepend_keymap]]
-on   = "t"
+on   = [ "t", "t" ]
 run  = "plugin smart-tab"
 desc = "Create a tab and enter the hovered directory"
 ```
@@ -225,7 +225,7 @@ The above example is for Hyprland + Hyprpaper, adapt to the command of your resp
 
 ## Linux: Copy selected files to the system clipboard while yanking {#selected-files-to-clipboard}
 
-Yazi allows multiple commands to be bound to a single key, so you can set <kbd>y</kbd> to not only do the `yank` but also run a shell script:
+Yazi allows multiple actions to be bound to a single key, so you can set <kbd>y</kbd> to not only do the `yank` but also run a shell script:
 
 ```toml
 [[mgr.prepend_keymap]]


### PR DESCRIPTION
Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
