### PR TITLE
Fix command syntax for yazi in quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -140,7 +140,7 @@ del "%tmpfile%"
 def _y(args):
 	tmp = $(mktemp -t "yazi-cwd.XXXXXX")
 	args.append(f"--cwd-file={tmp}")
-	$[!yazi @(args)]
+	$[yazi @(args)]
 	with open(tmp) as f:
 		cwd = f.read()
 	import os


### PR DESCRIPTION
this is what worked for me with 
yazi 25.5.31
xonsh 0.22.1
python 3.11.13

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [ ] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
