### PR TITLE
docs: prevent null path error in PS `y` shell wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -103,7 +103,7 @@ function y {
 	$tmp = (New-TemporaryFile).FullName
 	yazi.exe $args --cwd-file="$tmp"
 	$cwd = Get-Content -Path $tmp -Encoding UTF8
-	if ($cwd -ne $PWD.Path -and (Test-Path -LiteralPath $cwd -PathType Container)) {
+	if ($cwd -and $cwd -ne $PWD.Path -and (Test-Path -LiteralPath $cwd -PathType Container)) {
 		Set-Location -LiteralPath (Resolve-Path -LiteralPath $cwd).Path
 	}
 	Remove-Item -Path $tmp

--- a/versioned_docs/version-26.1.22/quick-start.md
+++ b/versioned_docs/version-26.1.22/quick-start.md
@@ -103,7 +103,7 @@ function y {
 	$tmp = (New-TemporaryFile).FullName
 	yazi.exe $args --cwd-file="$tmp"
 	$cwd = Get-Content -Path $tmp -Encoding UTF8
-	if ($cwd -ne $PWD.Path -and (Test-Path -LiteralPath $cwd -PathType Container)) {
+	if ($cwd -and $cwd -ne $PWD.Path -and (Test-Path -LiteralPath $cwd -PathType Container)) {
 		Set-Location -LiteralPath (Resolve-Path -LiteralPath $cwd).Path
 	}
 	Remove-Item -Path $tmp


### PR DESCRIPTION
Add explicit null check for `$cwd` before calling `Test-Path` in PowerShell 'y' function. This avoids errors when yazi.exe does not return a valid directory path.

## Checklist

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
