### PR TITLE
docs: document fs.unique and fs.access

### DIFF
--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -854,6 +854,11 @@ local ok, err = fd:write_all("Hello, World!")
 assert(ok, err)
 ```
 
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation succeeds, which is a `boolean`.
+- `err`: [`Error`][error] of the failure.
+
 | In/Out    | Type               |
 | --------- | ------------------ |
 | `self`    | `Self`             |
@@ -874,6 +879,11 @@ assert(fd, err)
 local ok, err = fd:flush()
 assert(ok, err)
 ```
+
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation succeeds, which is a `boolean`.
+- `err`: [`Error`][error] of the failure.
 
 | In/Out    | Type               |
 | --------- | ------------------ |

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -549,7 +549,7 @@ local ok, err = fs.write(url, "hello world")
 
 ### `access()` {#fs.access}
 
-Access the file system by returning an [Access](#access) object.
+Create an [`Access`](#access) with which to access the filesystem.
 
 ```lua
 local access = fs.access()
@@ -705,14 +705,13 @@ end
 Create a file or a directory with the unique name from the given `url` to ensure it's unique in the file system:
 
 ```lua
-local file_url, err1 = fs.unique("file", Url("/tmp/test.txt"))
-local dir_url, err2 = fs.unique("dir", Url("/tmp/temp"))
+local url, err = fs.unique("file", Url("/tmp/test.txt"))
 ```
 
 Where `type` can be one of the following:
 
-- `"file"`: Creates a file with the unique name in the file system.
-- `"dir"`: Creates a directory with the unique name in the file system.
+- `"file"`: Creates a file with the unique name.
+- `"dir"`: Creates a directory with the unique name.
 
 If the file already exists, it will append `_n` to the filename, where `n` is a number, and keep incrementing until the first available name is found.
 
@@ -742,7 +741,7 @@ local access = fs.access():read(true)
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `self`    | `self`             |
+| `self`    | `Self`             |
 | `read`    | `boolean`          |
 | Return    | `self`             |
 | Available | Async context only |
@@ -757,7 +756,7 @@ local access = fs.access():write(true)
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `self`    | `self`             |
+| `self`    | `Self`             |
 | `write`   | `boolean`          |
 | Return    | `self`             |
 | Available | Async context only |
@@ -772,7 +771,7 @@ local access = fs.access():append(true)
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `self`    | `self`             |
+| `self`    | `Self`             |
 | `append`  | `boolean`          |
 | Return    | `self`             |
 | Available | Async context only |
@@ -787,7 +786,7 @@ local access = fs.access():truncate(true)
 
 | In/Out     | Type               |
 | ---------- | ------------------ |
-| `self`     | `self`             |
+| `self`     | `Self`             |
 | `truncate` | `boolean`          |
 | Return     | `self`             |
 | Available  | Async context only |
@@ -802,7 +801,7 @@ local access = fs.access():create(true)
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `self`    | `self`             |
+| `self`    | `Self`             |
 | `create`  | `boolean`          |
 | Return    | `self`             |
 | Available | Async context only |
@@ -817,7 +816,7 @@ local access = fs.access():create_new(true)
 
 | In/Out       | Type               |
 | ------------ | ------------------ |
-| `self`       | `self`             |
+| `self`       | `Self`             |
 | `create_new` | `boolean`          |
 | Return       | `self`             |
 | Available    | Async context only |
@@ -827,17 +826,18 @@ local access = fs.access():create_new(true)
 Opens a file at `url` with the mode specified.
 
 ```lua
-local fd, err = fs.access():read(true):open(Url("/tmp/test.txt"))
+local url = Url("/tmp/test.txt")
+local fd, err = fs.access():read(true):open(url)
 ```
 
 Returns `(fd, err)`:
 
-- `fd`: The [Fd](#fd) (file descriptor) object to work with the file.
+- `fd`: [Fd](#fd) (file descriptor) if the operation succeeds; otherwise, `nil`.
 - `err`: [`Error`][error] of the failure.
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `self`    | `self`             |
+| `self`    | `Self`             |
 | `url`     | `Url`              |
 | Return    | `Fd?, Error?`      |
 | Available | Async context only |
@@ -852,20 +852,16 @@ Writes all `bytes` to the file descriptor.
 
 ```lua
 local url = Url("/tmp/test.txt")
-local fd, err = fs.access():read(true):open(url)
+local fd, err = fs.access():write(true):open(url)
 
 if fd then
 	fd:write_all("Hello, World!")
-	fd:flush()
-
-	-- Calling ya.drop after flush closes the file immediately
-	ya.drop(fd)
 end
 ```
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `self`    | `self`             |
+| `self`    | `Self`             |
 | `bytes`   | `string`           |
 | Return    | `Error?`           |
 | Available | Async context only |
@@ -876,14 +872,11 @@ Flushes the file descriptor, making sure all data gets written to the underlying
 
 ```lua
 local url = Url("/tmp/test.txt")
-local fd, err = fs.access():read(true):open(url)
+local fd, err = fs.access():write(true):open(url)
 
 if fd then
 	fd:write_all("Hello, World!")
 	fd:flush()
-
-	-- Calling ya.drop after flush closes the file immediately
-	ya.drop(fd)
 end
 ```
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -846,18 +846,19 @@ Writes all `bytes` to the file descriptor.
 
 ```lua
 local url = Url("/tmp/test.txt")
-local fd, err = fs.access():write(true):open(url)
 
-if fd then
-	fd:write_all("Hello, World!")
-end
+local fd, err = fs.access():write(true):open(url)
+assert(fd, err)
+
+local ok, err = fd:write_all("Hello, World!")
+assert(ok, err)
 ```
 
 | In/Out    | Type               |
 | --------- | ------------------ |
 | `self`    | `Self`             |
 | `bytes`   | `string`           |
-| Return    | `Error?`           |
+| Return    | `boolean, Error?`  |
 | Available | Async context only |
 
 ### `flush(self)`
@@ -866,18 +867,18 @@ Flushes the file descriptor, making sure all data gets written to the underlying
 
 ```lua
 local url = Url("/tmp/test.txt")
-local fd, err = fs.access():write(true):open(url)
 
-if fd then
-	fd:write_all("Hello, World!")
-	fd:flush()
-end
+local fd, err = fs.access():write(true):open(url)
+assert(fd, err)
+
+local ok, err = fd:flush()
+assert(ok, err)
 ```
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `self`    | `self`             |
-| Return    | `Error?`           |
+| `self`    | `Self`             |
+| Return    | `boolean, Error?`  |
 | Available | Async context only |
 
 ## ui {#ui}

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -722,7 +722,7 @@ Returns `(url, err)`:
 
 | In/Out    | Type               |
 | --------- | ------------------ |
-| `type`    | `"file"\|"dir"`    |
+| `type`    | `"file"` \| `"dir"`|
 | `url`     | `Url`              |
 | Return    | `Url?, Error?`     |
 | Available | Async context only |

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -547,9 +547,22 @@ local ok, err = fs.write(url, "hello world")
 | Return    | `boolean, Error?`  |
 | Available | Async context only |
 
+### `access()` {#fs.access}
+
+Access the file system by returning an [Access](#access) object.
+
+```lua
+local access = fs.access()
+```
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| Return    | `Access`           |
+| Available | Async context only |
+
 ### `create(type, url)` {#fs.create}
 
-Create file(s) at the `url` of the file system:
+Create directory/directories at the `url` of the file system:
 
 ```lua
 local ok, err = fs.create("dir_all", Url("/tmp/test/nest/nested"))
@@ -687,13 +700,19 @@ end
 | Return    | `boolean, Error?`  |
 | Available | Async context only |
 
-### `unique_name(url)` {#fs.unique_name}
+### `unique(type, url)` {#fs.unique}
 
-Get a unique name from the given `url` to ensure it's unique in the file system:
+Create a file or a directory with the unique name from the given `url` to ensure it's unique in the file system:
 
 ```lua
-local url, err = fs.unique_name(Url("/tmp/test.txt"))
+local file_url, err1 = fs.unique("file", Url("/tmp/test.txt"))
+local dir_url, err2 = fs.unique("dir", Url("/tmp/temp"))
 ```
+
+Where `type` can be one of the following:
+
+- `"file"`: Creates a file with the unique name in the file system.
+- `"dir"`: Creates a directory with the unique name in the file system.
 
 If the file already exists, it will append `_n` to the filename, where `n` is a number, and keep incrementing until the first available name is found.
 
@@ -704,8 +723,174 @@ Returns `(url, err)`:
 
 | In/Out    | Type               |
 | --------- | ------------------ |
+| `type`    | `"file"\|"dir"`    |
 | `url`     | `Url`              |
 | Return    | `Url?, Error?`     |
+| Available | Async context only |
+
+## Access {#access}
+
+This object is created by [`fs.access()`](#fs.access) and represents the options for interacting with a file.
+
+### `read(self, read)` {#access.read}
+
+Sets the operation for read access.
+
+```lua
+local access = fs.access():read(true)
+```
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `self`             |
+| `read`    | `boolean`          |
+| Return    | `self`             |
+| Available | Async context only |
+
+### `write(self, write)` {#access.write}
+
+Sets the operation for write access.
+
+```lua
+local access = fs.access():write(true)
+```
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `self`             |
+| `write`   | `boolean`          |
+| Return    | `self`             |
+| Available | Async context only |
+
+### `append(self, append)` {#access.append}
+
+Sets the operation for the append mode.
+
+```lua
+local access = fs.access():append(true)
+```
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `self`             |
+| `append`  | `boolean`          |
+| Return    | `self`             |
+| Available | Async context only |
+
+### `truncate(self, truncate)` {#access.truncate}
+
+Sets the operation for truncating a previous file.
+
+```lua
+local access = fs.access():truncate(true)
+```
+
+| In/Out     | Type               |
+| ---------- | ------------------ |
+| `self`     | `self`             |
+| `truncate` | `boolean`          |
+| Return     | `self`             |
+| Available  | Async context only |
+
+### `create(self, create)` {#access.create}
+
+Sets the operation to create a new file, or open it if it already exists.
+
+```lua
+local access = fs.access():create(true)
+```
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `self`             |
+| `create`  | `boolean`          |
+| Return    | `self`             |
+| Available | Async context only |
+
+### `create_new(self, create_new)` {#access.create_new}
+
+Sets the operation to create a new file, failing if it already exists.
+
+```lua
+local access = fs.access():create_new(true)
+```
+
+| In/Out       | Type               |
+| ------------ | ------------------ |
+| `self`       | `self`             |
+| `create_new` | `boolean`          |
+| Return       | `self`             |
+| Available    | Async context only |
+
+### `open(self, url)` {#access.open}
+
+Opens a file at `url` with the mode specified.
+
+```lua
+local fd, err = fs.access():read(true):open(Url("/tmp/test.txt"))
+```
+
+Returns `(fd, err)`:
+
+- `fd`: The [Fd](#fd) (file descriptor) object to work with the file.
+- `err`: [`Error`][error] of the failure.
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `self`             |
+| `url`     | `Url`              |
+| Return    | `Fd?, Error?`      |
+| Available | Async context only |
+
+## Fd {#fd}
+
+This object is created by [`Access:open()`](#access.open) and contains the methods for working with the opened file.
+
+### `write_all(self, bytes)`
+
+Writes all `bytes` to the file descriptor.
+
+```lua
+local url = Url("/tmp/test.txt")
+local fd, err = fs.access():read(true):open(url)
+
+if fd then
+	fd:write_all("Hello, World!")
+	fd:flush()
+
+	-- Calling ya.drop after flush closes the file immediately
+	ya.drop(fd)
+end
+```
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `self`             |
+| `bytes`   | `string`           |
+| Return    | `Error?`           |
+| Available | Async context only |
+
+### `flush(self)`
+
+Flushes the file descriptor, making sure all data gets written to the underlying storage.
+
+```lua
+local url = Url("/tmp/test.txt")
+local fd, err = fs.access():read(true):open(url)
+
+if fd then
+	fd:write_all("Hello, World!")
+	fd:flush()
+
+	-- Calling ya.drop after flush closes the file immediately
+	ya.drop(fd)
+end
+```
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `self`             |
+| Return    | `Error?`           |
 | Available | Async context only |
 
 ## ui {#ui}

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -836,61 +836,6 @@ Returns `(fd, err)`:
 | Return    | `Fd?, Error?`      |
 | Available | Async context only |
 
-## Fd {#fd}
-
-This object is created by [`Access:open()`](#access.open) and contains the methods for working with the opened file.
-
-### `write_all(self, bytes)` {#fd.write_all}
-
-Writes all `bytes` to the file descriptor.
-
-```lua
-local url = Url("/tmp/test.txt")
-
-local fd, err = fs.access():write(true):open(url)
-assert(fd, err)
-
-local ok, err = fd:write_all("Hello, World!")
-assert(ok, err)
-```
-
-Returns `(ok, err)`:
-
-- `ok`: Whether the operation succeeds, which is a `boolean`.
-- `err`: [`Error`][error] of the failure.
-
-| In/Out    | Type               |
-| --------- | ------------------ |
-| `self`    | `Self`             |
-| `bytes`   | `string`           |
-| Return    | `boolean, Error?`  |
-| Available | Async context only |
-
-### `flush(self)` {#fd.flush}
-
-Flushes the file descriptor, making sure all data gets written to the underlying storage.
-
-```lua
-local url = Url("/tmp/test.txt")
-
-local fd, err = fs.access():write(true):open(url)
-assert(fd, err)
-
-local ok, err = fd:flush()
-assert(ok, err)
-```
-
-Returns `(ok, err)`:
-
-- `ok`: Whether the operation succeeds, which is a `boolean`.
-- `err`: [`Error`][error] of the failure.
-
-| In/Out    | Type               |
-| --------- | ------------------ |
-| `self`    | `Self`             |
-| Return    | `boolean, Error?`  |
-| Available | Async context only |
-
 ## ui {#ui}
 
 APIs related to the user interface.
@@ -1050,6 +995,61 @@ ps.unsub_remote("my-message")
 | ------ | --------- | ----------------- |
 | `kind` | `string`  | Same as `unsub()` |
 | Return | `unknown` | -                 |
+
+## Fd {#fd}
+
+This object is created by [`Access:open()`](#access.open) and contains the methods for working with the opened file.
+
+### `write_all(self, bytes)` {#fd.write_all}
+
+Writes all `bytes` to the file descriptor.
+
+```lua
+local url = Url("/tmp/test.txt")
+
+local fd, err = fs.access():write(true):open(url)
+assert(fd, err)
+
+local ok, err = fd:write_all("Hello, World!")
+assert(ok, err)
+```
+
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation succeeds, which is a `boolean`.
+- `err`: [`Error`][error] of the failure.
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `Self`             |
+| `bytes`   | `string`           |
+| Return    | `boolean, Error?`  |
+| Available | Async context only |
+
+### `flush(self)` {#fd.flush}
+
+Flushes the file descriptor, making sure all data gets written to the underlying storage.
+
+```lua
+local url = Url("/tmp/test.txt")
+
+local fd, err = fs.access():write(true):open(url)
+assert(fd, err)
+
+local ok, err = fd:flush()
+assert(ok, err)
+```
+
+Returns `(ok, err)`:
+
+- `ok`: Whether the operation succeeds, which is a `boolean`.
+- `err`: [`Error`][error] of the failure.
+
+| In/Out    | Type               |
+| --------- | ------------------ |
+| `self`    | `Self`             |
+| Return    | `boolean, Error?`  |
+| Available | Async context only |
 
 ## Command {#command}
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -562,7 +562,7 @@ local access = fs.access()
 
 ### `create(type, url)` {#fs.create}
 
-Create directory/directories at the `url` of the file system:
+Create directories at the given filesystem `url`:
 
 ```lua
 local ok, err = fs.create("dir_all", Url("/tmp/test/nest/nested"))

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -840,7 +840,7 @@ Returns `(fd, err)`:
 
 This object is created by [`Access:open()`](#access.open) and contains the methods for working with the opened file.
 
-### `write_all(self, bytes)`
+### `write_all(self, bytes)` {#fd.write_all}
 
 Writes all `bytes` to the file descriptor.
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -739,12 +739,11 @@ Sets the operation for read access.
 local access = fs.access():read(true)
 ```
 
-| In/Out    | Type               |
-| --------- | ------------------ |
-| `self`    | `Self`             |
-| `read`    | `boolean`          |
-| Return    | `self`             |
-| Available | Async context only |
+| In/Out | Type      |
+| ------ | --------- |
+| `self` | `Self`    |
+| `read` | `boolean` |
+| Return | `self`    |
 
 ### `write(self, write)` {#access.write}
 
@@ -754,12 +753,11 @@ Sets the operation for write access.
 local access = fs.access():write(true)
 ```
 
-| In/Out    | Type               |
-| --------- | ------------------ |
-| `self`    | `Self`             |
-| `write`   | `boolean`          |
-| Return    | `self`             |
-| Available | Async context only |
+| In/Out  | Type      |
+| ------- | --------- |
+| `self`  | `Self`    |
+| `write` | `boolean` |
+| Return  | `self`    |
 
 ### `append(self, append)` {#access.append}
 
@@ -769,12 +767,11 @@ Sets the operation for the append mode.
 local access = fs.access():append(true)
 ```
 
-| In/Out    | Type               |
-| --------- | ------------------ |
-| `self`    | `Self`             |
-| `append`  | `boolean`          |
-| Return    | `self`             |
-| Available | Async context only |
+| In/Out   | Type      |
+| -------- | --------- |
+| `self`   | `Self`    |
+| `append` | `boolean` |
+| Return   | `self`    |
 
 ### `truncate(self, truncate)` {#access.truncate}
 
@@ -784,12 +781,11 @@ Sets the operation for truncating a previous file.
 local access = fs.access():truncate(true)
 ```
 
-| In/Out     | Type               |
-| ---------- | ------------------ |
-| `self`     | `Self`             |
-| `truncate` | `boolean`          |
-| Return     | `self`             |
-| Available  | Async context only |
+| In/Out     | Type      |
+| ---------- | --------- |
+| `self`     | `Self`    |
+| `truncate` | `boolean` |
+| Return     | `self`    |
 
 ### `create(self, create)` {#access.create}
 
@@ -799,12 +795,11 @@ Sets the operation to create a new file, or open it if it already exists.
 local access = fs.access():create(true)
 ```
 
-| In/Out    | Type               |
-| --------- | ------------------ |
-| `self`    | `Self`             |
-| `create`  | `boolean`          |
-| Return    | `self`             |
-| Available | Async context only |
+| In/Out   | Type      |
+| -------- | --------- |
+| `self`   | `Self`    |
+| `create` | `boolean` |
+| Return   | `self`    |
 
 ### `create_new(self, create_new)` {#access.create_new}
 
@@ -814,12 +809,11 @@ Sets the operation to create a new file, failing if it already exists.
 local access = fs.access():create_new(true)
 ```
 
-| In/Out       | Type               |
-| ------------ | ------------------ |
-| `self`       | `Self`             |
-| `create_new` | `boolean`          |
-| Return       | `self`             |
-| Available    | Async context only |
+| In/Out       | Type      |
+| ------------ | --------- |
+| `self`       | `Self`    |
+| `create_new` | `boolean` |
+| Return       | `self`    |
 
 ### `open(self, url)` {#access.open}
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -731,7 +731,7 @@ Returns `(url, err)`:
 
 This object is created by [`fs.access()`](#fs.access) and represents the options for interacting with a file.
 
-### `read(self, read)` {#access.read}
+### `read(self, read)` {#Access.read}
 
 Sets the operation for read access.
 
@@ -745,7 +745,7 @@ local access = fs.access():read(true)
 | `read` | `boolean` |
 | Return | `self`    |
 
-### `write(self, write)` {#access.write}
+### `write(self, write)` {#Access.write}
 
 Sets the operation for write access.
 
@@ -759,7 +759,7 @@ local access = fs.access():write(true)
 | `write` | `boolean` |
 | Return  | `self`    |
 
-### `append(self, append)` {#access.append}
+### `append(self, append)` {#Access.append}
 
 Sets the operation for the append mode.
 
@@ -773,7 +773,7 @@ local access = fs.access():append(true)
 | `append` | `boolean` |
 | Return   | `self`    |
 
-### `truncate(self, truncate)` {#access.truncate}
+### `truncate(self, truncate)` {#Access.truncate}
 
 Sets the operation for truncating a previous file.
 
@@ -787,7 +787,7 @@ local access = fs.access():truncate(true)
 | `truncate` | `boolean` |
 | Return     | `self`    |
 
-### `create(self, create)` {#access.create}
+### `create(self, create)` {#Access.create}
 
 Sets the operation to create a new file, or open it if it already exists.
 
@@ -801,7 +801,7 @@ local access = fs.access():create(true)
 | `create` | `boolean` |
 | Return   | `self`    |
 
-### `create_new(self, create_new)` {#access.create_new}
+### `create_new(self, create_new)` {#Access.create_new}
 
 Sets the operation to create a new file, failing if it already exists.
 
@@ -815,7 +815,7 @@ local access = fs.access():create_new(true)
 | `create_new` | `boolean` |
 | Return       | `self`    |
 
-### `open(self, url)` {#access.open}
+### `open(self, url)` {#Access.open}
 
 Opens a file at `url` with the mode specified.
 
@@ -1000,7 +1000,7 @@ ps.unsub_remote("my-message")
 
 This object is created by [`Access:open()`](#access.open) and contains the methods for working with the opened file.
 
-### `write_all(self, bytes)` {#fd.write_all}
+### `write_all(self, bytes)` {#Fd.write_all}
 
 Writes all `bytes` to the file descriptor.
 
@@ -1026,7 +1026,7 @@ Returns `(ok, err)`:
 | Return    | `boolean, Error?`  |
 | Available | Async context only |
 
-### `flush(self)` {#fd.flush}
+### `flush(self)` {#Fd.flush}
 
 Flushes the file descriptor, making sure all data gets written to the underlying storage.
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -866,7 +866,7 @@ Returns `(ok, err)`:
 | Return    | `boolean, Error?`  |
 | Available | Async context only |
 
-### `flush(self)`
+### `flush(self)` {#fd.flush}
 
 Flushes the file descriptor, making sure all data gets written to the underlying storage.
 

--- a/docs/plugins/utils.md
+++ b/docs/plugins/utils.md
@@ -720,12 +720,12 @@ Returns `(url, err)`:
 - `url`: The [`Url`][url] with the unique filename.
 - `err`: [`Error`][error] of the failure.
 
-| In/Out    | Type               |
-| --------- | ------------------ |
-| `type`    | `"file"` \| `"dir"`|
-| `url`     | `Url`              |
-| Return    | `Url?, Error?`     |
-| Available | Async context only |
+| In/Out    | Type                |
+| --------- | ------------------- |
+| `type`    | `"file"` \| `"dir"` |
+| `url`     | `Url`               |
+| Return    | `Url?, Error?`      |
+| Available | Async context only  |
 
 ## Access {#access}
 


### PR DESCRIPTION
Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
