### PR TITLE
docs: add cargo binstall instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -411,7 +411,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update
 ```
 
-You can install `yazi-build` via `cargo install`, which will in turn install `yazi-fm` and `yazi-cli`:
+Now you can install `yazi-build` via `cargo`, which will in turn install `yazi-fm` and `yazi-cli`:
 
 ```sh
 cargo install --force yazi-build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -411,8 +411,6 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update
 ```
 
-### `cargo install` {#cargo-install}
-
 You can install `yazi-build` via `cargo install`, which will in turn install `yazi-fm` and `yazi-cli`:
 
 ```sh
@@ -427,9 +425,9 @@ cargo install --force --git https://github.com/sxyazi/yazi.git yazi-build
 
 If it fails to build, please check if `make` and `gcc` is installed on your system.
 
-### `cargo binstall` {#cargo-binstall}
+## Cargo Binstall {#cargo-binstall}
 
-Alternatively, you can install `yazi-fm` via `cargo binstall`, which will install both `yazi-fm` and `yazi-cli` automatically:
+To install Yazi's binary release with [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
 cargo binstall yazi-fm

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -411,7 +411,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update
 ```
 
-Now you can install `yazi-build` via `cargo`, which will in turn install `yazi-fm` and `yazi-cli`:
+### `cargo install` {#cargo-install}
+
+You can install `yazi-build` via `cargo install`, which will in turn install `yazi-fm` and `yazi-cli`:
 
 ```sh
 cargo install --force yazi-build
@@ -424,6 +426,14 @@ cargo install --force --git https://github.com/sxyazi/yazi.git yazi-build
 ```
 
 If it fails to build, please check if `make` and `gcc` is installed on your system.
+
+### `cargo binstall` {#cargo-binstall}
+
+Alternatively, you can install `yazi-fm` via `cargo binstall`, which will install both `yazi-fm` and `yazi-cli` automatically:
+
+```sh
+cargo binstall yazi-fm
+```
 
 ## Build from source {#source}
 

--- a/versioned_docs/version-26.1.22/installation.md
+++ b/versioned_docs/version-26.1.22/installation.md
@@ -410,8 +410,6 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update
 ```
 
-### `cargo install` {#cargo-install}
-
 You can install `yazi-build` via `cargo install`, which will in turn install `yazi-fm` and `yazi-cli`:
 
 ```sh
@@ -426,9 +424,9 @@ cargo install --force --git https://github.com/sxyazi/yazi.git yazi-build
 
 If it fails to build, please check if `make` and `gcc` is installed on your system.
 
-### `cargo binstall` {#cargo-binstall}
+## Cargo Binstall {#cargo-binstall}
 
-Alternatively, you can install `yazi-fm` via `cargo binstall`, which will install both `yazi-fm` and `yazi-cli` automatically:
+To install Yazi's binary release with [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
 cargo binstall yazi-fm

--- a/versioned_docs/version-26.1.22/installation.md
+++ b/versioned_docs/version-26.1.22/installation.md
@@ -410,7 +410,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update
 ```
 
-Now you can install `yazi-build` via `cargo`, which will in turn install `yazi-fm` and `yazi-cli`:
+### `cargo install` {#cargo-install}
+
+You can install `yazi-build` via `cargo install`, which will in turn install `yazi-fm` and `yazi-cli`:
 
 ```sh
 cargo install --force yazi-build
@@ -423,6 +425,14 @@ cargo install --force --git https://github.com/sxyazi/yazi.git yazi-build
 ```
 
 If it fails to build, please check if `make` and `gcc` is installed on your system.
+
+### `cargo binstall` {#cargo-binstall}
+
+Alternatively, you can install `yazi-fm` via `cargo binstall`, which will install both `yazi-fm` and `yazi-cli` automatically:
+
+```sh
+cargo binstall yazi-fm
+```
 
 ## Build from source {#source}
 

--- a/versioned_docs/version-26.1.22/installation.md
+++ b/versioned_docs/version-26.1.22/installation.md
@@ -410,7 +410,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update
 ```
 
-You can install `yazi-build` via `cargo install`, which will in turn install `yazi-fm` and `yazi-cli`:
+Now you can install `yazi-build` via `cargo`, which will in turn install `yazi-fm` and `yazi-cli`:
 
 ```sh
 cargo install --force yazi-build


### PR DESCRIPTION
Closes #332.

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
