### PR TITLE
docs: fix syntax for padding example in theme.md

### DIFF
--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -231,7 +231,7 @@ Indicator bar style, in the preview pane.
 
 ### `padding` {#indicator.padding}
 
-Padding around indicator bar, e.g. `{ open = "█", close = "█" }`, which makes a square indicator.
+Padding around indicator bar, e.g. `{ open = "▐", close = "▌" }`, which makes a square indicator.
 
 |      |                                   |
 | ---- | --------------------------------- |

--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -231,7 +231,7 @@ Indicator bar style, in the preview pane.
 
 ### `padding` {#indicator.padding}
 
-Padding around indicator bar, e.g. `{ open: "█", close: "█" }`, which makes a square indicator.
+Padding around indicator bar, e.g. `{ open = "█", close = "█" }`, which makes a square indicator.
 
 |      |                                   |
 | ---- | --------------------------------- |

--- a/versioned_docs/version-26.1.22/configuration/theme.md
+++ b/versioned_docs/version-26.1.22/configuration/theme.md
@@ -231,7 +231,7 @@ Indicator bar style, in the preview pane.
 
 ### `padding` {#indicator.padding}
 
-Padding around indicator bar, e.g. `{ open = "█", close = "█" }`, which makes a square indicator.
+Padding around indicator bar, e.g. `{ open = "▐", close = "▌" }`, which makes a square indicator.
 
 |      |                                   |
 | ---- | --------------------------------- |

--- a/versioned_docs/version-26.1.22/configuration/theme.md
+++ b/versioned_docs/version-26.1.22/configuration/theme.md
@@ -231,7 +231,7 @@ Indicator bar style, in the preview pane.
 
 ### `padding` {#indicator.padding}
 
-Padding around indicator bar, e.g. `{ open: "█", close: "█" }`, which makes a square indicator.
+Padding around indicator bar, e.g. `{ open = "█", close = "█" }`, which makes a square indicator.
 
 |      |                                   |
 | ---- | --------------------------------- |


### PR DESCRIPTION
Minor syntax fix for padding example in theme.md

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
