### PR TITLE
docs: add pypi installation for yazi

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -381,6 +381,18 @@ alias yazi="flatpak run io.github.sxyazi.yazi"
 
 See the Flatpak edition's [README](https://github.com/flathub/io.github.sxyazi.yazi) for more information.
 
+## PyPI {#pypi}
+
+:::info
+This uses an [unofficial PyPI package](https://github.com/Bing-su/pip-binary-factory) maintained by [Dowon](https://github.com/Bing-su).
+:::
+
+```sh
+pipx install yazi-bin
+# Or
+uv tool install yazi-bin
+```
+
 ## AOSC OS {#aosc}
 
 ```sh
@@ -392,18 +404,6 @@ sudo oma install yazi ffmpeg p7zip jq poppler fd ripgrep fzf zoxide imagemagick
 ```sh
 x env use yazi ffmpeg 7zz jq fd rg fzf zoxide magick
 ```
-
-## Pypi {#pypi}
-
-You can install `yazi` and `ya` both by installing [yazi-bin](https://pypi.org/project/yazi-bin/) package from Pypi.
-
-```sh
-pipx install yazi-bin
-# OR
-uv tool install yazi-bin
-```
-
-Since Python is present in every machine by default today, this is a really easy way to install Yazi and use on your (remote) machines.
 
 ## Official binaries {#binaries}
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -393,6 +393,18 @@ sudo oma install yazi ffmpeg p7zip jq poppler fd ripgrep fzf zoxide imagemagick
 x env use yazi ffmpeg 7zz jq fd rg fzf zoxide magick
 ```
 
+## Pypi {#pypi}
+
+You can install `yazi` and `ya` both by installing [yazi-bin](https://pypi.org/project/yazi-bin/) package from Pypi.
+
+```sh
+pipx install yazi-bin
+# OR
+uv tool install yazi-bin
+```
+
+Since Python is present in every machine by default today, this is a really easy way to install Yazi and use on your (remote) machines.
+
 ## Official binaries {#binaries}
 
 You can download the latest official binaries from GitHub Releases: https://github.com/sxyazi/yazi/releases


### PR DESCRIPTION
Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi


## What is this PR?

Adds installation of yazi from Pypi. Closes #249. This applies to both nightly and stable versions so i checked both the boxes, hope thats ok!
Do edit the PR if any edits are necessary. Thanks!