### PR TITLE
Add exiftool.yazi plugin to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -29,6 +29,10 @@ Archives:
 - [zless-preview.yazi](https://github.com/vmikk/zless-preview.yazi) - Preview compressed text files using `zless`.
 - [comicthumb.yazi](https://github.com/navysky12/comicthumb.yazi) - Preview for comicbook archive files using p7zip on Linux.
 
+Binaries:
+
+- [exiftool.yazi](https://github.com/AleMenon/exiftool.yazi) - Preview metadata from executable files using `exiftool`.
+
 Documents:
 
 - [djvu-view.yazi](https://github.com/Shallow-Seek/djvu-view.yazi) - Preview Djvu using `ddjvu` from [djvulibre](https://github.com/DjvuNet/DjVuLibre)

--- a/versioned_docs/version-26.1.22/resources.md
+++ b/versioned_docs/version-26.1.22/resources.md
@@ -29,6 +29,10 @@ Archives:
 - [zless-preview.yazi](https://github.com/vmikk/zless-preview.yazi) - Preview compressed text files using `zless`.
 - [comicthumb.yazi](https://github.com/navysky12/comicthumb.yazi) - Preview for comicbook archive files using p7zip on Linux.
 
+Binaries:
+
+- [exiftool.yazi](https://github.com/AleMenon/exiftool.yazi) - Preview metadata from executable files using `exiftool`.
+
 Documents:
 
 - [djvu-view.yazi](https://github.com/Shallow-Seek/djvu-view.yazi) - Preview Djvu using `ddjvu` from [djvulibre](https://github.com/DjvuNet/DjVuLibre)


### PR DESCRIPTION
Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
