### PR TITLE
Fix directory change condition in quick-start.md

### DIFF
--- a/versioned_docs/version-26.1.22/quick-start.md
+++ b/versioned_docs/version-26.1.22/quick-start.md
@@ -127,7 +127,7 @@ if not exist "%tmpfile%" exit /b 0
 
 :: If the file exist, then read the content and change the directory
 set /p cwd=<"%tmpfile%"
-if not "%cwd%"=="" if exist "%cwd%\NUL" (
+if not "%cwd%"=="" if exist "%cwd%\" (
 	cd /d "%cwd%"
 )
 del "%tmpfile%"


### PR DESCRIPTION
NUL is inconsistent for paths with spaces and ending with trailing backslashes