### PR TITLE
docs: fix cmd shell wrapper

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -127,8 +127,7 @@ if not exist "%tmpfile%" exit /b 0
 
 :: If the file exist, then read the content and change the directory
 set /p cwd=<"%tmpfile%"
-if not "%cwd:~-1%"=="\" set "cwd=%cwd%\"
-if not "%cwd%"=="" if exist "%cwd%" (
+if not "%cwd%"=="" if exist "%cwd%\" (
 	cd /d "%cwd%"
 )
 del "%tmpfile%"

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -127,7 +127,8 @@ if not exist "%tmpfile%" exit /b 0
 
 :: If the file exist, then read the content and change the directory
 set /p cwd=<"%tmpfile%"
-if not "%cwd%"=="" if exist "%cwd%\NUL" (
+if not "%cwd:~-1%"=="\" set "cwd=%cwd%\"
+if not "%cwd%"=="" if exist "%cwd%" (
 	cd /d "%cwd%"
 )
 del "%tmpfile%"

--- a/versioned_docs/version-26.1.22/quick-start.md
+++ b/versioned_docs/version-26.1.22/quick-start.md
@@ -127,8 +127,7 @@ if not exist "%tmpfile%" exit /b 0
 
 :: If the file exist, then read the content and change the directory
 set /p cwd=<"%tmpfile%"
-if not "%cwd:~-1%"=="\" set "cwd=%cwd%\"
-if not "%cwd%"=="" if exist "%cwd%" (
+if not "%cwd%"=="" if exist "%cwd%\" (
 	cd /d "%cwd%"
 )
 del "%tmpfile%"

--- a/versioned_docs/version-26.1.22/quick-start.md
+++ b/versioned_docs/version-26.1.22/quick-start.md
@@ -127,7 +127,8 @@ if not exist "%tmpfile%" exit /b 0
 
 :: If the file exist, then read the content and change the directory
 set /p cwd=<"%tmpfile%"
-if not "%cwd%"=="" if exist "%cwd%\NUL" (
+if not "%cwd:~-1%"=="\" set "cwd=%cwd%\"
+if not "%cwd%"=="" if exist "%cwd%" (
 	cd /d "%cwd%"
 )
 del "%tmpfile%"


### PR DESCRIPTION
Resolves https://github.com/yazi-rs/yazi-rs.github.io/pull/363

The `\NUL` trick for directory detection is known to not work properly when used with quotes ([link](https://superuser.com/questions/1858400/windows-command-line-checking-existence-of-folder-directory-using-nul-device-d)). The next alternative to use a trailing slash instead. I'm not sure if the directory check is even needed since yazi seems to always send back a directory string anyway.

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
