### PR TITLE
docs: use `command rm`

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -29,7 +29,7 @@ function y() {
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
 	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd"
-	rm -f -- "$tmp"
+	command rm -f -- "$tmp"
 }
 ```
 
@@ -43,7 +43,7 @@ function y
 	if read -z cwd < "$tmp"; and [ "$cwd" != "$PWD" ]; and test -d "$cwd"
 		builtin cd -- "$cwd"
 	end
-	rm -f -- "$tmp"
+	command rm -f -- "$tmp"
 end
 ```
 
@@ -70,7 +70,7 @@ y() {
 	set -- "$@" --cwd-file "$(mktemp -t yazi-cwd.XXXXXX)"
 	command yazi "$@"
 	shift $(($# - 1))
-	set -- "$(command cat < "$1"; printf .; rm -f -- "$1")"
+	set -- "$(command cat < "$1"; printf .; command rm -f -- "$1")"
 	set -- "${1%.}"
 	[ "$1" != "$PWD" ] && [ -d "$1" ] && command cd -- "$1"
 }

--- a/versioned_docs/version-26.5.6/quick-start.md
+++ b/versioned_docs/version-26.5.6/quick-start.md
@@ -29,7 +29,7 @@ function y() {
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
 	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd"
-	rm -f -- "$tmp"
+	command rm -f -- "$tmp"
 }
 ```
 
@@ -43,7 +43,7 @@ function y
 	if read -z cwd < "$tmp"; and [ "$cwd" != "$PWD" ]; and test -d "$cwd"
 		builtin cd -- "$cwd"
 	end
-	rm -f -- "$tmp"
+	command rm -f -- "$tmp"
 end
 ```
 
@@ -70,7 +70,7 @@ y() {
 	set -- "$@" --cwd-file "$(mktemp -t yazi-cwd.XXXXXX)"
 	command yazi "$@"
 	shift $(($# - 1))
-	set -- "$(command cat < "$1"; printf .; rm -f -- "$1")"
+	set -- "$(command cat < "$1"; printf .; command rm -f -- "$1")"
 	set -- "${1%.}"
 	[ "$1" != "$PWD" ] && [ -d "$1" ] && command cd -- "$1"
 }


### PR DESCRIPTION
If one uses something like `alias rm=safe-rm` which moves files to trash bin, yazi would back every temp files up, so `command rm` would be better.

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
