### PR TITLE
add wise-enter.yazi plugin to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -123,7 +123,7 @@ Clipboard:
 - [smart-enter.yazi](https://github.com/yazi-rs/plugins/tree/main/smart-enter.yazi) - `Open` files or `enter` directories all in one key!
 - [bypass.yazi](https://github.com/Rolv-Apneseth/bypass.yazi) - Yazi plugin for skipping directories with only a single sub-directory.
 - [fast-enter.yazi](https://github.com/ourongxing/fast-enter.yazi) - Auto-decompress archives and enter them, or enter the deepest directory until it's not the only subdirectory.
-- [wise-enter.yazi](https://github.com/jaam8/wise-enter.yazi) - Yazi plugin: enter the deepest subfolder, extract archives, open files - all in one key.
+- [wise-enter.yazi](https://github.com/jaam8/wise-enter.yazi) - Enter the deepest subfolder, extract archives, open files - all in one key.
 
 `shell` enhancements:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -123,6 +123,7 @@ Clipboard:
 - [smart-enter.yazi](https://github.com/yazi-rs/plugins/tree/main/smart-enter.yazi) - `Open` files or `enter` directories all in one key!
 - [bypass.yazi](https://github.com/Rolv-Apneseth/bypass.yazi) - Yazi plugin for skipping directories with only a single sub-directory.
 - [fast-enter.yazi](https://github.com/ourongxing/fast-enter.yazi) - Auto-decompress archives and enter them, or enter the deepest directory until it's not the only subdirectory.
+- [wise-enter.yazi](https://github.com/jaam8/wise-enter.yazi) - Yazi plugin: enter the deepest subfolder, extract archives, open files - all in one key.
 
 `shell` enhancements:
 

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -123,7 +123,7 @@ Clipboard:
 - [smart-enter.yazi](https://github.com/yazi-rs/plugins/tree/main/smart-enter.yazi) - `Open` files or `enter` directories all in one key!
 - [bypass.yazi](https://github.com/Rolv-Apneseth/bypass.yazi) - Yazi plugin for skipping directories with only a single sub-directory.
 - [fast-enter.yazi](https://github.com/ourongxing/fast-enter.yazi) - Auto-decompress archives and enter them, or enter the deepest directory until it's not the only subdirectory.
-- [wise-enter.yazi](https://github.com/jaam8/wise-enter.yazi) - Yazi plugin: enter the deepest subfolder, extract archives, open files - all in one key.
+- [wise-enter.yazi](https://github.com/jaam8/wise-enter.yazi) - Enter the deepest subfolder, extract archives, open files - all in one key.
 
 `shell` enhancements:
 

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -123,6 +123,7 @@ Clipboard:
 - [smart-enter.yazi](https://github.com/yazi-rs/plugins/tree/main/smart-enter.yazi) - `Open` files or `enter` directories all in one key!
 - [bypass.yazi](https://github.com/Rolv-Apneseth/bypass.yazi) - Yazi plugin for skipping directories with only a single sub-directory.
 - [fast-enter.yazi](https://github.com/ourongxing/fast-enter.yazi) - Auto-decompress archives and enter them, or enter the deepest directory until it's not the only subdirectory.
+- [wise-enter.yazi](https://github.com/jaam8/wise-enter.yazi) - Yazi plugin: enter the deepest subfolder, extract archives, open files - all in one key.
 
 `shell` enhancements:
 


### PR DESCRIPTION
Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
