### PR TITLE
add macos-trash.yazi plugin to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -99,6 +99,7 @@ File actions:
 - [restore.yazi](https://github.com/boydaihungst/restore.yazi) - Restore/recover latest deleted files/folders using `trash-cli`.
 - [recycle-bin.yazi](https://github.com/uhs-robert/recycle-bin.yazi) - Manage your Trash from Yazi: browse contents, restore or delete selected items, empty by age, or empty completely using `trash-cli`.
 - [omni-trash.yazi](https://github.com/goon/omni-trash.yazi) - Manage your trash across all drives in a single unified interface using `trash-cli` to delete and restore selected items or empty every trash directory at once.
+- [macos-trash.yazi](https://github.com/walavave/macos-trash.yazi) - **(macOS-only)** Manage your trash using [`trash-cli-macos`](https://github.com/walavave/trash-cli) to browse contents, select items to restore or delete, empty all, or empty by modification date.
 - [gvfs.yazi](https://github.com/boydaihungst/gvfs.yazi) - Mount and manage MTP, GPhoto2 (PTP) devices (Android, Cameras, etc), SMB, SFTP, NFS, FTP, Google Drive, DNS-SD, DAV (WebDAV), AFP, AFC (Linux only). List of [supported protocals](<https://wiki.gnome.org/Projects(2f)gvfs(2f)schemes.html>).
 - [kdeconnect-send.yazi](https://github.com/Deepak22903/kdeconnect-send.yazi) - Send selected files to your smartphone or other devices using KDE Connect.
 - [zoom.yazi](https://github.com/yazi-rs/plugins/tree/main/zoom.yazi) - Zoom in or out of the preview image.

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -99,6 +99,7 @@ File actions:
 - [restore.yazi](https://github.com/boydaihungst/restore.yazi) - Restore/recover latest deleted files/folders using `trash-cli`.
 - [recycle-bin.yazi](https://github.com/uhs-robert/recycle-bin.yazi) - Manage your Trash from Yazi: browse contents, restore or delete selected items, empty by age, or empty completely using `trash-cli`.
 - [omni-trash.yazi](https://github.com/goon/omni-trash.yazi) - Manage your trash across all drives in a single unified interface using `trash-cli` to delete and restore selected items or empty every trash directory at once.
+- [macos-trash.yazi](https://github.com/walavave/macos-trash.yazi) - **(macOS-only)** Manage your trash using [`trash-cli-macos`](https://github.com/walavave/trash-cli) to browse contents, select items to restore or delete, empty all, or empty by modification date.
 - [gvfs.yazi](https://github.com/boydaihungst/gvfs.yazi) - Mount and manage MTP, GPhoto2 (PTP) devices (Android, Cameras, etc), SMB, SFTP, NFS, FTP, Google Drive, DNS-SD, DAV (WebDAV), AFP, AFC (Linux only). List of [supported protocals](<https://wiki.gnome.org/Projects(2f)gvfs(2f)schemes.html>).
 - [kdeconnect-send.yazi](https://github.com/Deepak22903/kdeconnect-send.yazi) - Send selected files to your smartphone or other devices using KDE Connect.
 - [zoom.yazi](https://github.com/yazi-rs/plugins/tree/main/zoom.yazi) - Zoom in or out of the preview image.


### PR DESCRIPTION
Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi

---

Suggest that `recycle-bin.yazi` , `omni-trash.yazi` and `restore.yazi` should add **Linux only**, as the `trash-cli` they use can't work properly on macOS.