### PR TITLE
Document per-OS keybinds

### DIFF
--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -81,22 +81,6 @@ keymap = [
 ]
 ```
 
-## Per-OS keybinds {#per-os-keybinds}
-Yazi supports per-OS keybinds through the `for` option; if not specified, the keybind is available on all systems. Available values:
-  - `linux`: Linux
-  - `macos`: macOS
-  - `windows`: Windows
-  - `android`: Android (Termux)
-  - `unix`: Linux, macOS, and Android
-
-```toml
-[mgr]
-prepend_keymap = [
-    # this keymap only exists for Windows
-    { on = ["g", "a"], run = "cd ~/AppData/Roaming", desc = "Goto %APPDATA%", for = "windows" },
-]
-```
-
 ## Key notation {#notation}
 
 You can specify one or more keys in the `on` of each keybinding rule, and each key can be represented with the following notations:
@@ -136,6 +120,26 @@ Note that:
 
 [CSI u]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 [Control character]: https://en.wikipedia.org/wiki/Control_character
+
+## Per-OS keybindings {#per-os}
+
+You can use `for` to limit a keybinding to a specific OS; if not specified, the keybinding is available on all systems. Available values:
+
+- `"linux"`: Linux
+- `"macos"`: macOS
+- `"windows"`: Windows
+- `"android"`: Android (Termux)
+- `"unix"`: Linux, macOS, and Android
+
+For example:
+
+```toml
+[mgr]
+prepend_keymap = [
+	{ on = [ "g", "d" ], run = "cd ~/dev",  desc = "Go dev",    for = "unix" },
+	{ on = [ "g", "d" ], run = 'cd C:\dev', desc = 'Go C:\dev', for = "windows" },
+]
+```
 
 ## [mgr] {#mgr}
 

--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -81,6 +81,22 @@ keymap = [
 ]
 ```
 
+## Per-OS keybinds {#per-os-keybinds}
+Yazi supports per-OS keybinds through the `for` option; if not specified, the keybind is available on all systems. Available values:
+  - `linux`: Linux
+  - `macos`: macOS
+  - `windows`: Windows
+  - `android`: Android (Termux)
+  - `unix`: Linux, macOS, and Android
+
+```toml
+[mgr]
+prepend_keymap = [
+    # this keymap only exists for Windows
+    { on = ["g", "a"], run = "cd ~/AppData/Roaming", desc = "Goto %APPDATA%", for = "windows" },
+]
+```
+
 ## Key notation {#notation}
 
 You can specify one or more keys in the `on` of each keybinding rule, and each key can be represented with the following notations:

--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -234,7 +234,7 @@ Available options are as follows:
 - `block`: Open in a blocking manner. After setting this, Yazi will hide into a secondary screen and display the program on the main screen until it exits. During this time, it can receive I/O signals, which is useful for interactive programs.
 - `orphan`: Keep the process running even if Yazi has exited, once specified, the process will be detached from the task scheduling system.
 - `desc`: Description of the opener, display in interactive components, such as "Open with" and help menu.
-- `for`: The opener is only available on this system, similar to keybinds. See [per-OS keybinds](/docs/configuration/keymap#per-os-keybinds).
+- `for`: The opener is only available on this system, similar to [per-OS keybindings](/docs/configuration/keymap#per-os).
 
 ## [open] {#open}
 

--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -234,12 +234,7 @@ Available options are as follows:
 - `block`: Open in a blocking manner. After setting this, Yazi will hide into a secondary screen and display the program on the main screen until it exits. During this time, it can receive I/O signals, which is useful for interactive programs.
 - `orphan`: Keep the process running even if Yazi has exited, once specified, the process will be detached from the task scheduling system.
 - `desc`: Description of the opener, display in interactive components, such as "Open with" and help menu.
-- `for`: The opener is only available on this system; if not specified, it's available on all systems. Available values:
-  - `linux`: Linux
-  - `macos`: macOS
-  - `windows`: Windows
-  - `android`: Android (Termux)
-  - `unix`: Linux, macOS, and Android
+- `for`: The opener is only available on this system, similar to keybinds. See [per-OS keybinds](/docs/configuration/keymap#per-os-keybinds).
 
 ## [open] {#open}
 

--- a/versioned_docs/version-26.5.6/configuration/keymap.md
+++ b/versioned_docs/version-26.5.6/configuration/keymap.md
@@ -81,22 +81,6 @@ keymap = [
 ]
 ```
 
-## Per-OS keybinds {#per-os-keybinds}
-Yazi supports per-OS keybinds through the `for` option; if not specified, the keybind is available on all systems. Available values:
-  - `linux`: Linux
-  - `macos`: macOS
-  - `windows`: Windows
-  - `android`: Android (Termux)
-  - `unix`: Linux, macOS, and Android
-
-```toml
-[mgr]
-prepend_keymap = [
-    # this keymap only exists for Windows
-    { on = ["g", "a"], run = "cd ~/AppData/Roaming", desc = "Goto %APPDATA%", for = "windows" },
-]
-```
-
 ## Key notation {#notation}
 
 You can specify one or more keys in the `on` of each keybinding rule, and each key can be represented with the following notations:
@@ -136,6 +120,26 @@ Note that:
 
 [CSI u]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 [Control character]: https://en.wikipedia.org/wiki/Control_character
+
+## Per-OS keybindings {#per-os}
+
+You can use `for` to limit a keybinding to a specific OS; if not specified, the keybinding is available on all systems. Available values:
+
+- `"linux"`: Linux
+- `"macos"`: macOS
+- `"windows"`: Windows
+- `"android"`: Android (Termux)
+- `"unix"`: Linux, macOS, and Android
+
+For example:
+
+```toml
+[mgr]
+prepend_keymap = [
+	{ on = [ "g", "d" ], run = "cd ~/dev",  desc = "Go dev",    for = "unix" },
+	{ on = [ "g", "d" ], run = 'cd C:\dev', desc = 'Go C:\dev', for = "windows" },
+]
+```
 
 ## [mgr] {#mgr}
 

--- a/versioned_docs/version-26.5.6/configuration/keymap.md
+++ b/versioned_docs/version-26.5.6/configuration/keymap.md
@@ -81,6 +81,22 @@ keymap = [
 ]
 ```
 
+## Per-OS keybinds {#per-os-keybinds}
+Yazi supports per-OS keybinds through the `for` option; if not specified, the keybind is available on all systems. Available values:
+  - `linux`: Linux
+  - `macos`: macOS
+  - `windows`: Windows
+  - `android`: Android (Termux)
+  - `unix`: Linux, macOS, and Android
+
+```toml
+[mgr]
+prepend_keymap = [
+    # this keymap only exists for Windows
+    { on = ["g", "a"], run = "cd ~/AppData/Roaming", desc = "Goto %APPDATA%", for = "windows" },
+]
+```
+
 ## Key notation {#notation}
 
 You can specify one or more keys in the `on` of each keybinding rule, and each key can be represented with the following notations:

--- a/versioned_docs/version-26.5.6/configuration/yazi.md
+++ b/versioned_docs/version-26.5.6/configuration/yazi.md
@@ -234,7 +234,7 @@ Available options are as follows:
 - `block`: Open in a blocking manner. After setting this, Yazi will hide into a secondary screen and display the program on the main screen until it exits. During this time, it can receive I/O signals, which is useful for interactive programs.
 - `orphan`: Keep the process running even if Yazi has exited, once specified, the process will be detached from the task scheduling system.
 - `desc`: Description of the opener, display in interactive components, such as "Open with" and help menu.
-- `for`: The opener is only available on this system, similar to keybinds. See [per-OS keybinds](/docs/configuration/keymap#per-os-keybinds).
+- `for`: The opener is only available on this system, similar to [per-OS keybindings](/docs/configuration/keymap#per-os).
 
 ## [open] {#open}
 

--- a/versioned_docs/version-26.5.6/configuration/yazi.md
+++ b/versioned_docs/version-26.5.6/configuration/yazi.md
@@ -234,12 +234,7 @@ Available options are as follows:
 - `block`: Open in a blocking manner. After setting this, Yazi will hide into a secondary screen and display the program on the main screen until it exits. During this time, it can receive I/O signals, which is useful for interactive programs.
 - `orphan`: Keep the process running even if Yazi has exited, once specified, the process will be detached from the task scheduling system.
 - `desc`: Description of the opener, display in interactive components, such as "Open with" and help menu.
-- `for`: The opener is only available on this system; if not specified, it's available on all systems. Available values:
-  - `linux`: Linux
-  - `macos`: macOS
-  - `windows`: Windows
-  - `android`: Android (Termux)
-  - `unix`: Linux, macOS, and Android
+- `for`: The opener is only available on this system, similar to keybinds. See [per-OS keybinds](/docs/configuration/keymap#per-os-keybinds).
 
 ## [open] {#open}
 


### PR DESCRIPTION
Documented per-OS keybinds and adjusted the `opener` docs to point to the `per-os-keybinds` header, since users will probably see the keymap docs first

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
