### PR TITLE
Add vscode-git-colors, vscode-git-gutter, mobile-auto-layout to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -53,6 +53,7 @@ Misc:
 
 - [mdv-previewer.yazi](https://github.com/WhoSowSee/mdv-previewer.yazi) - A preview plugin for Text and Markdown files that uses [mdv](https://github.com/WhoSowSee/mdv) to render content
 - [rich-preview.yazi](https://github.com/AnirudhG07/rich-preview.yazi) - Preview Markdown, JSON, CSV, etc. using [rich-cli](https://github.com/textualize/rich-cli)
+- [vscode-git-gutter.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-gutter.yazi) - Preview text and code with syntax highlighting, line numbers, and a VS Code style git change gutter.
 
 ## 🧩 Functional plugins {#functional}
 
@@ -158,6 +159,8 @@ UI enhancements:
 - [no-status.yazi](https://github.com/yazi-rs/plugins/tree/main/no-status.yazi) - Remove the status bar.
 - [pref-by-location.yazi](https://github.com/boydaihungst/pref-by-location.yazi) - Save and restore linemode/sorting/hidden preferences based on directory location.
 - [linemode-plus.yazi](https://github.com/barbanevosa/linemode-plus.yazi) - Advanced linemode customization with configurable date format and combined size+mtime view.
+- [vscode-git-colors.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-colors.yazi) - Color file names by their git status, VS Code style, with status letters for files and dot badges for directories in every column.
+- [mobile-auto-layout.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/mobile-auto-layout.yazi) - Adapt column widths to content and screen size, with a reading mode that widens the preview, built for phone-narrow terminals.
 
 Diagnostics:
 

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -53,6 +53,7 @@ Misc:
 
 - [mdv-previewer.yazi](https://github.com/WhoSowSee/mdv-previewer.yazi) - A preview plugin for Text and Markdown files that uses [mdv](https://github.com/WhoSowSee/mdv) to render content
 - [rich-preview.yazi](https://github.com/AnirudhG07/rich-preview.yazi) - Preview Markdown, JSON, CSV, etc. using [rich-cli](https://github.com/textualize/rich-cli)
+- [vscode-git-gutter.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-gutter.yazi) - Preview text and code with syntax highlighting, line numbers, and a VS Code style git change gutter.
 
 ## 🧩 Functional plugins {#functional}
 
@@ -158,6 +159,8 @@ UI enhancements:
 - [no-status.yazi](https://github.com/yazi-rs/plugins/tree/main/no-status.yazi) - Remove the status bar.
 - [pref-by-location.yazi](https://github.com/boydaihungst/pref-by-location.yazi) - Save and restore linemode/sorting/hidden preferences based on directory location.
 - [linemode-plus.yazi](https://github.com/barbanevosa/linemode-plus.yazi) - Advanced linemode customization with configurable date format and combined size+mtime view.
+- [vscode-git-colors.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-colors.yazi) - Color file names by their git status, VS Code style, with status letters for files and dot badges for directories in every column.
+- [mobile-auto-layout.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/mobile-auto-layout.yazi) - Adapt column widths to content and screen size, with a reading mode that widens the preview, built for phone-narrow terminals.
 
 Diagnostics:
 


### PR DESCRIPTION
Three yazi plugins, built and tested against yazi 26.5.6.

- vscode-git-colors: VS Code style git status colors and badges on file names, in every column.
- vscode-git-gutter: VS Code style change gutter in the text preview, scrolls instantly.
- mobile-auto-layout: columns size themselves to their content and your screen. Scrolling the preview flips to a near fullscreen reading mode; built for phone terminals, comfortable on laptops.

![git colors](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/git-colors.png)

changes are shown in the gutter margin like vscode

![change gutter](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/git-gutter.png)

mobile-auto-layout on a laptop, browse and reading mode:

Browse mode:
![browse on laptop](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/auto-layout-browse.png)

Reading mode collapses a panel so the preview panel shows up with more width:
![reading on laptop](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/auto-layout-reading.png)

And on a phone:

on phone only two panels are shown
<img src="https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/phone-browse.png" width="320">

in reading mode the preview panel takes up most of the width
<img src="https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/phone-portrait.png" width="320">
