### PR TITLE
Update Debian repository domain in install docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -309,8 +309,9 @@ This uses an [unofficial deb repository](https://github.com/dariogriffo/yazi-deb
 :::
 
 ```sh
-curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
-echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://deb.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/deb.griffo.io.gpg
+echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list
 sudo apt update
 sudo apt install yazi
 ```


### PR DESCRIPTION
Follow-up to #342.

The community Debian repository moved from `debian.griffo.io` to `deb.griffo.io` to comply with the [Debian trademark policy](https://www.debian.org/trademark) — same repository and signing key, and the old domain redirects permanently. While here, the snippet now uses the modern `/etc/apt/keyrings` + `signed-by=` layout (key trusted only for this repo instead of globally) and adds the previously missing `sudo` on the `gpg` write to `/etc`.