### PR TITLE
Update folder-specific rule snippet

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -119,12 +119,19 @@ The following code demonstrates making the `Downloads` directory to sort by modi
 
 ```lua
 local function setup()
+	local sorted = false
 	ps.sub("ind-sort", function(opt)
 		local cwd = cx.active.current.cwd
 		if cwd:ends_with("Downloads") then
-			opt.by, opt.reverse, opt.dir_first = "mtime", true, false
+			if not sorted then
+				sorted = true
+				opt.by, opt.reverse, opt.dir_first = "mtime", true, false
+			end
 		else
-			opt.by, opt.reverse, opt.dir_first = "natural", false, true
+			if sorted then
+				sorted = false
+				opt.by, opt.reverse, opt.dir_first = "natural", false, true
+			end
 		end
 		return opt
 	end)

--- a/versioned_docs/version-26.5.6/tips.md
+++ b/versioned_docs/version-26.5.6/tips.md
@@ -119,12 +119,19 @@ The following code demonstrates making the `Downloads` directory to sort by modi
 
 ```lua
 local function setup()
+	local sorted = false
 	ps.sub("ind-sort", function(opt)
 		local cwd = cx.active.current.cwd
 		if cwd:ends_with("Downloads") then
-			opt.by, opt.reverse, opt.dir_first = "mtime", true, false
+			if not sorted then
+				sorted = true
+				opt.by, opt.reverse, opt.dir_first = "mtime", true, false
+			end
 		else
-			opt.by, opt.reverse, opt.dir_first = "natural", false, true
+			if sorted then
+				sorted = false
+				opt.by, opt.reverse, opt.dir_first = "natural", false, true
+			end
 		end
 		return opt
 	end)


### PR DESCRIPTION
Add a boolean check to ensure manual sort does not get overridden by the frequent "ind-sort" messages.

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [X] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [X] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
