### PR TITLE
Show default values (dynamically)

### DIFF
--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -3,6 +3,7 @@ sidebar_position: 2
 description: Learn how to configure keyboard shortcuts with Yazi.
 ---
 
+import Default, {Defaults, DefaultWithProp} from "@site/src/components/Default";
 import KeymapArrow from './keymap-arrow.md'
 
 # keymap.toml
@@ -158,6 +159,8 @@ Cancel find, exit visual mode, clear selected, cancel filter, or cancel search.
 
 Automatically determine the operation by default, and it will only execute the selected operation after specifying the option; multiple options can be stacked.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="escape"/>
+
 ### `quit` {#mgr.quit}
 
 Exit the process.
@@ -166,6 +169,8 @@ Exit the process.
 | --------------- | ------------------------------------------------------------------------------ |
 | `--code=[n]`    | Exit code.                                                                     |
 | `--no-cwd-file` | Don't output the current directory to the file specified by `yazi --cwd-file`. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="quit"/>
 
 ### `close` {#mgr.close}
 
@@ -176,31 +181,45 @@ Close the current tab; if it's the last tab, exit the process instead.
 | `--code=[n]`    | Exit code used when exiting.                                                           |
 | `--no-cwd-file` | Don't output the current directory to the file specified by `yazi --cwd-file` on exit. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="close"/>
+
 ### `suspend` {#mgr.suspend}
 
 Pauses Yazi and returns to the parent shell to continue with other tasks.
 
 Once those tasks are done, use the `fg` command of the shell to send a resume signal and return back to Yazi.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="suspend"/>
+
 ### `arrow` {#mgr.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="arrow"/>
 
 ### `leave` {#mgr.leave}
 
 Go back to the parent directory of the hovered file, or the parent of the current working directory if no file is hovered on.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="leave"/>
+
 ### `enter` {#mgr.enter}
 
 Enter the child directory.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="enter"/>
 
 ### `back` {#mgr.back}
 
 Go back to the previous directory.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="back"/>
+
 ### `forward` {#mgr.forward}
 
 Go forward to the next directory.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="forward"/>
 
 ### `seek` {#mgr.seek}
 
@@ -210,9 +229,13 @@ Scroll the contents in the preview panel.
 | --------------- | ---------------------------------------------------------------- |
 | `[n]`           | Use negative values to seek up and positive values to seek down. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="seek"/>
+
 ### `spot` {#mgr.spot}
 
 Display file information with the preset or user-customized spotter.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="spot"/>
 
 ### `cd` {#mgr.cd}
 
@@ -253,9 +276,13 @@ desc = 'Cd to E:\Pictures'
 
 Check out the [resources page](/docs/resources) for a more comprehensive bookmark plugin.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="cd"/>
+
 ### `follow` {#mgr.follow}
 
 Follow the hovered file if it's a symbolic link.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="follow"/>
 
 ### `reveal` {#mgr.reveal}
 
@@ -267,6 +294,8 @@ If the file is not in the current directory, it will change the current director
 | --------------- | ------------------ |
 | `[url]`         | The URL to reveal. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="reveal"/>
+
 ### `toggle` {#mgr.toggle}
 
 Toggle the selection state of the hovered file.
@@ -276,6 +305,8 @@ Toggle the selection state of the hovered file.
 | N/A             | Reverse the selection. |
 | `--state=on`    | Select the file.       |
 | `--state=off`   | Deselect the file.     |
+
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^toggle[^_]"/>
 
 ### `toggle_all` {#mgr.toggle_all}
 
@@ -289,6 +320,8 @@ Toggle the selection state of all files in the current working directory.
 
 Note that `toggle_all --state=off` only deselect the files in CWD, if you have selected files across multiple directories, and want to deselect all of them, use [`escape --select`](#mgr.escape).
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="toggle_all"/>
+
 ### `visual_mode` {#mgr.visual_mode}
 
 Enter visual mode.
@@ -297,6 +330,8 @@ Enter visual mode.
 | --------------- | --------------- |
 | N/A             | Selection mode. |
 | `--unset`       | Unset mode.     |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="visual_mode"/>
 
 ### `open` {#mgr.open}
 
@@ -307,6 +342,8 @@ Open the selected files using [the rules in `[open]`](/docs/configuration/yazi#o
 | `--interactive` | Open the hovered/selected file(s) with an interactive UI to choose the opening method. |
 | `--hovered`     | Always open the hovered file regardless of the selection state.                        |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="open"/>
+
 ### `yank` {#mgr.yank}
 
 Yank the selected files.
@@ -316,9 +353,13 @@ Yank the selected files.
 | N/A             | Copy mode.  |
 | `--cut`         | Cut mode.   |
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^yank"/>
+
 ### `unyank` {#mgr.unyank}
 
 Cancel the yank status of files.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="^unyank"/>
 
 ### `paste` {#mgr.paste}
 
@@ -329,6 +370,8 @@ Paste the yanked files.
 | `--force`       | Overwrite the destination file if it exists.                                                                 |
 | `--follow`      | Copy the file pointed to by the symbolic link, rather than the link itself. Only can be used during copying. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="paste"/>
+
 ### `link` {#mgr.link}
 
 Create a symbolic link to the yanked files. (This is a privileged action on Windows and must be run as an administrator.)
@@ -338,6 +381,8 @@ Create a symbolic link to the yanked files. (This is a privileged action on Wind
 | `--relative`    | Use a relative path for the symbolic link.   |
 | `--force`       | Overwrite the destination file if it exists. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^link"/>
+
 ### `hardlink` {#mgr.hardlink}
 
 Hardlink the yanked files.
@@ -346,6 +391,8 @@ Hardlink the yanked files.
 | --------------- | ------------------------------------------------------------------------ |
 | `--force`       | Overwrite the destination file if it exists.                             |
 | `--follow`      | Hardlink the file pointed to by a symbolic link, not the symlink itself. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="hardlink"/>
 
 ### `remove` {#mgr.remove}
 
@@ -359,6 +406,8 @@ In the Android platform, you can only use it with the `--permanently` option, si
 | `--permanently` | Permanently delete the files.                                        |
 | `--hovered`     | Always remove the hovered file regardless of the selection state.    |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="remove"/>
+
 ### `create` {#mgr.create}
 
 Create a file or directory. Ends with `/` (Unix) or `\` (Windows) for directories.
@@ -367,6 +416,8 @@ Create a file or directory. Ends with `/` (Unix) or `\` (Windows) for directorie
 | --------------- | ---------------------------------------------------------------------------------------------- |
 | `--dir`         | Always create directories, regardless of whether end with `/` or `\`.                          |
 | `--force`       | Overwrite the destination file directly if it exists, without showing the confirmation dialog. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^create"/>
 
 ### `rename` {#mgr.rename}
 
@@ -387,6 +438,8 @@ Rename a file or directory, or bulk rename if multiple files are selected (`$EDI
 You can also use `--cursor` with `--empty`, for example, `rename --empty=stem --cursor=start` will empty the file's stem, and move the cursor to the start.
 
 Which causes the input box content for the filename `foo.jpg` to be `|.jpg`, where "|" represents the cursor position.
+
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^rename"/>
 
 ### `copy` {#mgr.copy}
 
@@ -413,6 +466,8 @@ Copy the URL of files or directories that are selected or hovered on.
 | -------- | ------------------------------------------------------------------- |
 | N/A      | Platform-specific separator, e.g. `\` for Windows and `/` for Unix. |
 | `"unix"` | Use `/` for all platforms.                                          |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="copy"/>
 
 ### `shell` {#mgr.shell}
 
@@ -455,6 +510,8 @@ desc = "Trash selected files"
 
 For complex shell scripts, you can use TOML's basic strings (`'''` or `"""`) to write them in multiple lines, as demonstrated in [this tip](/docs/tips#email-selected-files).
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="shell"/>
+
 ### `hidden` {#mgr.hidden}
 
 Set the visibility of hidden files.
@@ -464,6 +521,8 @@ Set the visibility of hidden files.
 | `"show"`        | Show hidden files.       |
 | `"hide"`        | Hide hidden files.       |
 | `"toggle"`      | Toggle the hidden state. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="hidden"/>
 
 ### `linemode` {#mgr.linemode}
 
@@ -477,6 +536,8 @@ Set the [line mode](/docs/configuration/yazi#mgr.linemode).
 | `"mtime"`       | Display the last modified time of the file.                                                                                                                                                         |
 | `"permissions"` | Display the permissions of the file, only available on Unix-like systems.                                                                                                                           |
 | `"owner"`       | Display the owner of the file, only available on Unix-like systems.                                                                                                                                 |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="linemode"/>
 
 ### `search` {#mgr.search}
 
@@ -506,6 +567,8 @@ desc = "Switch to the flat view with a max depth of 3"
 [rg]: https://github.com/BurntSushi/ripgrep
 [rga]: https://github.com/phiresky/ripgrep-all
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^search"/>
+
 ### `find` {#mgr.find}
 
 Find files in the current working directory interactively and incrementally.
@@ -516,6 +579,8 @@ Find files in the current working directory interactively and incrementally.
 | `--smart`       | Use smart-case when finding, i.e. case-sensitive if the query contains uppercase characters, otherwise case-insensitive. |
 | `--insensitive` | Use case-insensitive find.                                                                                               |
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="find[^_]"/>
+
 ### `find_arrow` {#mgr.find_arrow}
 
 Move the cursor to the next or previous occurrence.
@@ -524,12 +589,16 @@ Move the cursor to the next or previous occurrence.
 | --------------- | -------------------------------- |
 | `--previous`    | Move to the previous occurrence. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="find_arrow"/>
+
 ### `filter` {#mgr.filter}
 
 | Argument/Option | Description                                                                                                           |
 | --------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `--smart`       | Filter with smart-case, i.e. case-sensitive if the keyword contains uppercase characters, otherwise case-insensitive. |
 | `--insensitive` | Use case-insensitive filter.                                                                                          |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="filter"/>
 
 ### `sort` {#mgr.sort}
 
@@ -546,6 +615,8 @@ Move the cursor to the next or previous occurrence.
 - `--dir-first`: Display directories first. `--dir-first` or `--dir-first=yes` to enable, `--dir-first=no` to disable.
 - `--translit`: Transliterate filenames for sorting, see [sort_translit](/docs/configuration/yazi#mgr.sort_translit) for details. `--translit` or `--translit=yes` to enable, `--translit=no` to disable.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="sort"/>
+
 ### `tab_create` {#mgr.tab_create}
 
 | Argument/Option | Description                                         |
@@ -555,6 +626,8 @@ Move the cursor to the next or previous occurrence.
 
 If neither `[url]` nor `--current` is specified, will use the startup directory to create the tab.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_create"/>
+
 ### `tab_close` {#mgr.tab_close}
 
 | Argument/Option | Description                                     |
@@ -563,6 +636,8 @@ If neither `[url]` nor `--current` is specified, will use the startup directory 
 
 If you want to close the current tab, use the [`close`](/docs/configuration/keymap/#mgr.close) action instead.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_close"/>
+
 ### `tab_switch` {#mgr.tab_switch}
 
 | Argument/Option | Description                                                                                                              |
@@ -570,19 +645,27 @@ If you want to close the current tab, use the [`close`](/docs/configuration/keym
 | `[n]`           | Switch to the tab at position `n`, starting from 0.                                                                      |
 | `--relative`    | Switch to the tab at a position relative to the current tab. The value of `n` can be negative when using this parameter. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_switch"/>
+
 ### `tab_swap` {#mgr.tab_swap}
 
 | Argument/Option | Description                                                                                                                          |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `[n]`           | Swap the current tab with the tab at position `n`, where negative values move the tab forward, and positive values move it backward. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_swap"/>
+
 ### `help` {#mgr.help}
 
 Open the help menu.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="help"/>
+
 ### `plugin` {#mgr.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="plugin"/>
 
 ### `noop` {#mgr.noop}
 
@@ -606,19 +689,27 @@ run = [ "noop" ]  # The array can only have one element and must be "noop"
 
 The disabled keys won't trigger any actions when pressed and won't show up in the `which` component.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="noop"/>
+
 ## [tasks] {#tasks}
 
 ### `show` {#tasks.show}
 
 Show the task manager.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tasks:show"/>
+
 ### `close` {#tasks.close}
 
 Hide the task manager.
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="close"/>
+
 ### `arrow` {#tasks.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="tasks.keymap" prop="run" value="arrow"/>
 
 ### `inspect` {#tasks.inspect}
 
@@ -630,37 +721,54 @@ Inspect the task log:
 
 press `q` to exit the inspect view.
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="inspect"/>
+
 ### `cancel` {#tasks.cancel}
 
 Cancel the task.
+
+<DefaultWithProp id="tasks.keymap" prop="run" value="cancel"/>
 
 ### `help` {#tasks.help}
 
 Open the help menu.
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="help"/>
+
 ### `plugin` {#tasks.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="tasks.keymap" prop="run" value="plugin"/>
 
 ### `noop` {#tasks.noop}
 
 See [`noop` action](#mgr.noop).
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="noop"/>
+
 ## [spot] {#spot}
+
 
 ### `close` {#spot.close}
 
 Hide the spotter.
 
+<DefaultWithProp id="spot.keymap" prop="run" value="close"/>
+
 ### `arrow` {#spot.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="spot.keymap" prop="run" value="arrow"/>
 
 ### `swipe` {#spot.swipe}
 
 | Argument/Option | Description                                                                                  |
 | --------------- | -------------------------------------------------------------------------------------------- |
 | `[n]`           | Swipe `n` files up or down in the file list. Negative value for up, positive value for down. |
+
+<DefaultWithProp id="spot.keymap" prop="run" value="swipe"/>
 
 ### `copy` {#spot.copy}
 
@@ -670,17 +778,25 @@ Copy the content from the spotter.
 | --------------- | ---------------------------- |
 | `"cell"`        | Copy the selected table cell |
 
+<DefaultWithProp id="spot.keymap" prop="run" value="copy"/>
+
 ### `plugin` {#spot.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="spot.keymap" prop="run" value="plugin"/>
 
 ### `noop` {#spot.noop}
 
 See [`noop` action](#mgr.noop).
 
+<DefaultWithProp id="spot.keymap" prop="run" value="noop"/>
+
 ### `help` {#spot.help}
 
 Open the help menu.
+
+<DefaultWithProp id="spot.keymap" prop="run" value="help"/>
 
 ## [pick] {#pick}
 
@@ -692,21 +808,31 @@ Cancel the picker.
 | --------------- | ------------------ |
 | `--submit`      | Submit the picker. |
 
+<DefaultWithProp id="pick.keymap" prop="run" value="close"/>
+
 ### `arrow` {#pick.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="pick.keymap" prop="run" value="arrow"/>
 
 ### `help` {#pick.help}
 
 Open the help menu.
 
+<DefaultWithProp id="pick.keymap" prop="run" value="help"/>
+
 ### `plugin` {#pick.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
+<DefaultWithProp id="pick.keymap" prop="run" value="plugin"/>
+
 ### `noop` {#pick.noop}
 
 See [`noop` action](#mgr.noop).
+
+<DefaultWithProp id="pick.keymap" prop="run" value="noop"/>
 
 ## [input] {#input}
 
@@ -718,9 +844,13 @@ Cancel input.
 | --------------- | ----------------- |
 | `--submit`      | Submit the input. |
 
+<DefaultWithProp id="input.keymap" prop="run" value="close"/>
+
 ### `escape` {#input.escape}
 
 Go back the normal mode, or cancel input.
+
+<DefaultWithProp id="input.keymap" prop="run" value="escape"/>
 
 ### `move` {#input.move}
 
@@ -731,9 +861,13 @@ Move the cursor left or right.
 | `[n]`            | Move the cursor `n` characters left or right. Negative value for left, positive value for right. |
 | `--in-operating` | Move the cursor only if it's currently waiting for an operation.                                 |
 
+<DefaultWithProp id="input.keymap" prop="run" value="move" remove="delete"/>
+
 ### `backward` {#input.backward}
 
 Move back to the start of the current or previous word.
+
+<DefaultWithProp id="input.keymap" prop="run" regex="^backward"/>
 
 ### `forward` {#input.forward}
 
@@ -743,6 +877,8 @@ Move forward to the start of the next word.
 | --------------- | ---------------------------------------------------- |
 | `--end-of-word` | Move forward to the end of the current or next word. |
 
+<DefaultWithProp id="input.keymap" prop="run" regex="^forward"/>
+
 ### `insert` {#input.insert}
 
 Enter insert mode. This action is only available in normal mode.
@@ -751,9 +887,13 @@ Enter insert mode. This action is only available in normal mode.
 | --------------- | ------------------------ |
 | `--append`      | Insert after the cursor. |
 
+<DefaultWithProp id="input.keymap" prop="run" value="insert" remove="delete"/>
+
 ### `visual` {#input.visual}
 
 Enter visual mode. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="visual"/>
 
 ### `delete` {#input.delete}
 
@@ -764,9 +904,13 @@ Delete the selected characters. This action is only available in normal mode.
 | `--cut`         | Cut the selected characters into clipboard, instead of only deleting them. |
 | `--insert`      | Delete and enter insert mode.                                              |
 
+<DefaultWithProp id="input.keymap" prop="run" value="delete"/>
+
 ### `yank` {#input.yank}
 
 Copy the selected characters. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="yank"/>
 
 ### `paste` {#input.paste}
 
@@ -776,17 +920,25 @@ Paste the copied characters after the cursor. This action is only available in n
 | --------------- | ---------------------------------------------- |
 | `--before`      | Paste the copied characters before the cursor. |
 
+<DefaultWithProp id="input.keymap" prop="run" value="paste"/>
+
 ### `undo` {#input.undo}
 
 Undo the last operation. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="undo"/>
 
 ### `redo` {#input.redo}
 
 Redo the last operation. This action is only available in normal mode.
 
+<DefaultWithProp id="input.keymap" prop="run" value="redo"/>
+
 ### `help` {#input.help}
 
 Open the help menu. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="help"/>
 
 ### `backspace` {#input.backspace}
 
@@ -795,6 +947,8 @@ Delete the character before the cursor. This action is only available in insert 
 | Argument/Option | Description                            |
 | --------------- | -------------------------------------- |
 | `--under`       | Delete the character under the cursor. |
+
+<DefaultWithProp id="input.keymap" prop="run" value="backspace"/>
 
 ### `kill` {#input.kill}
 
@@ -807,13 +961,19 @@ Kill the specified range of characters. This action is only available in insert 
 | `"backward"`    | Kill backwards to the start of the current word. |
 | `"forward"`     | Kill forwards to the end of the current word.    |
 
+<DefaultWithProp id="input.keymap" prop="run" value="kill"/>
+
 ### `plugin` {#input.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin). This action is only available in normal mode.
 
+<DefaultWithProp id="input.keymap" prop="run" value="plugin"/>
+
 ### `noop` {#input.noop}
 
 See [`noop` action](#mgr.noop).
+
+<DefaultWithProp id="input.keymap" prop="run" value="noop"/>
 
 ## [confirm] {#confirm}
 
@@ -825,13 +985,19 @@ Cancel and close the confirmation dialog.
 | --------------- | ------------------------ |
 | `--submit`      | Submit the confirmation. |
 
+<DefaultWithProp id="confirm.keymap" prop="run" value="close"/>
+
 ### `arrow` {#confirm.arrow}
 
 <KeymapArrow />
 
+<DefaultWithProp id="confirm.keymap" prop="run" value="arrow"/>
+
 ### `help` {#confirm.help}
 
 Open the help menu.
+
+<DefaultWithProp id="confirm.keymap" prop="run" value="help"/>
 
 ## [cmp] {#cmp}
 
@@ -843,17 +1009,25 @@ Hide the completion menu.
 | --------------- | ---------------------- |
 | `--submit`      | Submit the completion. |
 
+<DefaultWithProp id="cmp.keymap" prop="run" value="close"/>
+
 ### `arrow` {#cmp.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="cmp.keymap" prop="run" value="arrow"/>
 
 ### `help` {#cmp.help}
 
 Open the help menu.
 
+<DefaultWithProp id="cmp.keymap" prop="run" value="help"/>
+
 ### `plugin` {#cmp.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="cmp.keymap" prop="run" value=""/>
 
 ### `noop` {#cmp.noop}
 
@@ -865,22 +1039,35 @@ See [`noop` action](#mgr.noop).
 
 Hide the help menu.
 
+<DefaultWithProp id="help.keymap" prop="run" value="close"/>
+
 ### `escape` {#help.escape}
 
 Clear the filter, or hide the help menu.
+
+<DefaultWithProp id="help.keymap" prop="run" value="escape"/>
 
 ### `arrow` {#help.arrow}
 
 <KeymapArrow />
 
+<DefaultWithProp id="help.keymap" prop="run" value="rrow"/>
+
 ### `filter` {#help.filter}
 
 Apply a filter for the help items.
+
+<DefaultWithProp id="help.keymap" prop="run" value="filter"/>
 
 ### `plugin` {#help.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
+<DefaultWithProp id="help.keymap" prop="run" value="plugin"/>
+
 ### `noop` {#help.noop}
 
 See [`noop` action](#mgr.noop).
+
+<DefaultWithProp id="help.keymap" prop="run" value="noop"/>
+

--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -4,6 +4,7 @@ description: Learn how to configure your Yazi theme.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import {DefaultTheme} from '@site/src/components/Default'
 
 # theme.toml
 
@@ -87,6 +88,8 @@ overall = { bg = "#1e1e2e" }
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="app.overall"/>
+
 ## [mgr] {#mgr}
 
 ### `cwd` {#mgr.cwd}
@@ -97,6 +100,8 @@ CWD text style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.cwd"/>
+
 ### `find_keyword` {#mgr.find_keyword}
 
 Style of the highlighted portion in the filename.
@@ -104,6 +109,8 @@ Style of the highlighted portion in the filename.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.find_keyword"/>
 
 ### `find_position` {#mgr.find_position}
 
@@ -113,6 +120,8 @@ Style of current file location in all found files to the right of the filename.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.find_position" />
+
 ### `symlink_target` {#mgr.symlink_target}
 
 Style for the path that a symbolic link points to, e.g., the ` -> /path/to/target` part in `my_symbolic_file -> /path/to/target`.
@@ -120,6 +129,8 @@ Style for the path that a symbolic link points to, e.g., the ` -> /path/to/targe
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.symlink_target" />
 
 ### `marker_copied` {#mgr.marker_copied}
 
@@ -129,6 +140,8 @@ Copied file marker style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.marker_copied" />
+
 ### `marker_cut` {#mgr.marker_cut}
 
 Cut file marker style.
@@ -136,6 +149,8 @@ Cut file marker style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.marker_cut" />
 
 ### `marker_marked` {#mgr.marker_marked}
 
@@ -145,6 +160,8 @@ Marker style of pre-selected file in visual mode.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.marker_marked" />
+
 ### `marker_selected` {#mgr.marker_selected}
 
 Selected file marker style.
@@ -152,6 +169,8 @@ Selected file marker style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.marker_selected" />
 
 ### `count_copied` {#mgr.count_copied}
 
@@ -161,6 +180,8 @@ Style of copied file number.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.count_copied" />
+
 ### `count_cut` {#mgr.count_cut}
 
 Style of cut file number.
@@ -168,6 +189,8 @@ Style of cut file number.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.count_cut" />
 
 ### `count_selected` {#mgr.count_selected}
 
@@ -177,6 +200,8 @@ Style of selected file number.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.count_selected" />
+
 ### `border_symbol` {#mgr.border_symbol}
 
 Border symbol, e.g. `"│"`.
@@ -185,6 +210,8 @@ Border symbol, e.g. `"│"`.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="mgr.border_symbol" />
+
 ### `border_style` {#mgr.border_style}
 
 Border style.
@@ -192,6 +219,8 @@ Border style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.border_style" />
 
 ### `syntect_theme` {#mgr.syntect_theme}
 
@@ -203,6 +232,9 @@ For example, `"~/Downloads/Dracula.tmTheme"`, not available after using a flavor
 | ---- | -------- |
 | Type | `string` |
 
+
+<DefaultTheme id="mgr.syntect_theme" />
+
 ## [indicator]
 
 ### `parent` {#indicator.parent}
@@ -213,6 +245,8 @@ Indicator bar style, in the parent pane.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="indicator.parent" />
+
 ### `current` {#indicator.current}
 
 Indicator bar style, in the current pane.
@@ -220,6 +254,8 @@ Indicator bar style, in the current pane.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="indicator.current" />
 
 ### `preview` {#indicator.preview}
 
@@ -229,6 +265,8 @@ Indicator bar style, in the preview pane.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="indicator.preview" />
+
 ### `padding` {#indicator.padding}
 
 Padding around indicator bar, e.g. `{ open = "▐", close = "▌" }`, which makes a square indicator.
@@ -236,6 +274,8 @@ Padding around indicator bar, e.g. `{ open = "▐", close = "▌" }`, which make
 |      |                                   |
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
+
+<DefaultTheme id="indicator.padding" />
 
 ## [tabs] {#tabs}
 
@@ -252,6 +292,8 @@ Active tab style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="tabs.active" />
+
 ### `inactive` {#tabs.inactive}
 
 Inactive tab style.
@@ -259,6 +301,8 @@ Inactive tab style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="tabs.inactive" />
 
 ### `sep_inner` {#tabs.sep_inner}
 
@@ -268,6 +312,8 @@ Inner separator symbol, e.g. `{ open = "[", close = "]" }`.
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
 
+<DefaultTheme id="tabs.sep_inner" />
+
 ### `sep_outer` {#tabs.sep_outer}
 
 Outer separator symbol, e.g. `{ open = "", close = "" }`.
@@ -275,6 +321,8 @@ Outer separator symbol, e.g. `{ open = "", close = "" }`.
 |      |                                   |
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
+
+<DefaultTheme id="tabs.sep_outer" />
 
 ## [mode] {#mode}
 
@@ -286,6 +334,8 @@ Normal mode main style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mode.normal_main" />
+
 ### `normal_alt` {#mode.normal_alt}
 
 Normal mode alternative style.
@@ -293,6 +343,8 @@ Normal mode alternative style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mode.normal_alt" />
 
 ### `select_main` {#mode.select_main}
 
@@ -302,6 +354,8 @@ Select mode main style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mode.select_main" />
+
 ### `select_alt` {#mode.select_alt}
 
 Select mode alternative style.
@@ -309,6 +363,8 @@ Select mode alternative style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mode.select_alt" />
 
 ### `unset_main` {#mode.unset_main}
 
@@ -318,6 +374,8 @@ Unset mode main style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mode.unset_main" />
+
 ### `unset_alt` {#mode.unset_alt}
 
 Unset mode alternative style.
@@ -325,6 +383,8 @@ Unset mode alternative style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mode.unset_alt" />
 
 ## [status] {#status}
 
@@ -341,6 +401,8 @@ Overall status bar style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.overall" />
+
 ### `sep_left` {#status.sep_left}
 
 Left separator symbol, e.g. `{ open = "", close = "]" }`.
@@ -348,6 +410,8 @@ Left separator symbol, e.g. `{ open = "", close = "]" }`.
 |      |                                   |
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
+
+<DefaultTheme id="status.sep_left" />
 
 ### `sep_right` {#status.sep_right}
 
@@ -357,6 +421,8 @@ Right separator symbol, e.g. `{ open = "[", close = "" }`.
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
 
+<DefaultTheme id="status.sep_right" />
+
 ### `perm_type` {#status.perm_type}
 
 Style of the file type symbol, such as `d` for directory, `-` for file, `l` for symlink, etc.
@@ -364,6 +430,8 @@ Style of the file type symbol, such as `d` for directory, `-` for file, `l` for 
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.perm_type" />
 
 ### `perm_read` {#status.perm_read}
 
@@ -373,6 +441,8 @@ Style of the read permission symbol (`r`).
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.perm_read" />
+
 ### `perm_write` {#status.perm_write}
 
 Style of the write permission symbol (`w`).
@@ -380,6 +450,8 @@ Style of the write permission symbol (`w`).
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.perm_write" />
 
 ### `perm_exec` {#status.perm_exec}
 
@@ -389,6 +461,8 @@ Style of the execute permission symbol (`x`).
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.perm_exec" />
+
 ### `perm_sep` {#status.perm_sep}
 
 Style of the permission separator symbol (`-`).
@@ -396,6 +470,8 @@ Style of the permission separator symbol (`-`).
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.perm_sep" />
 
 ### `progress_label` {#status.progress_label}
 
@@ -405,6 +481,8 @@ Progress label style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.progress_label" />
+
 ### `progress_normal` {#status.progress_normal}
 
 Style of the progress bar when it is not in an error state.
@@ -413,6 +491,8 @@ Style of the progress bar when it is not in an error state.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.progress_normal" />
+
 ### `progress_error` {#status.progress_error}
 
 Style of the progress bar when an error occurs.
@@ -420,6 +500,8 @@ Style of the progress bar when an error occurs.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.progress_error" />
 
 ## [which] {#which}
 
@@ -431,6 +513,8 @@ Number of columns.
 | ---- | ----------------- |
 | Type | `1` \| `2` \| `3` |
 
+<DefaultTheme id="which.cols" />
+
 ### `mask` {#which.mask}
 
 Mask style.
@@ -438,6 +522,8 @@ Mask style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="which.mask" />
 
 ### `cand` {#which.cand}
 
@@ -447,6 +533,8 @@ Candidate key style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="which.cand" />
+
 ### `rest` {#which.rest}
 
 Rest key style.
@@ -454,6 +542,8 @@ Rest key style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="which.rest" />
 
 ### `desc` {#which.desc}
 
@@ -463,6 +553,8 @@ Description style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="which.desc" />
+
 ### `separator` {#which.separator}
 
 Separator symbol, e.g. `" -> "`.
@@ -471,6 +563,8 @@ Separator symbol, e.g. `" -> "`.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="which.separator" />
+
 ### `separator_style` {#which.separator_style}
 
 Separator style.
@@ -478,6 +572,8 @@ Separator style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="which.separator_style" />
 
 ## [confirm] {#confirm}
 
@@ -489,6 +585,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="confirm.border" />
+
 ### `title` {#confirm.title}
 
 Title style.
@@ -496,6 +594,8 @@ Title style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="confirm.title" />
 
 ### `body` {#confirm.body}
 
@@ -505,6 +605,8 @@ Body style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="confirm.body" />
+
 ### `list` {#confirm.list}
 
 List style, which is the style of the list of items below the content.
@@ -512,6 +614,8 @@ List style, which is the style of the list of items below the content.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="confirm.list" />
 
 ### `btn_yes` {#confirm.btn_yes}
 
@@ -521,6 +625,8 @@ The style of the yes button.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="confirm.btn_yes" />
+
 ### `btn_no` {#confirm.btn_no}
 
 The style of the no button.
@@ -528,6 +634,8 @@ The style of the no button.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="confirm.btn_no" />
 
 ### `btn_labels` {#confirm.btn_labels}
 
@@ -538,6 +646,8 @@ The first string is the label for the yes button and the second is the label for
 |      |                    |
 | ---- | ------------------ |
 | Type | `[string, string]` |
+
+<DefaultTheme id="confirm.btn_labels" />
 
 ## [spot] {#spot}
 
@@ -554,6 +664,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="spot.border" />
+
 ### `title` {#spot.title}
 
 Title style.
@@ -561,6 +673,8 @@ Title style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="spot.title" />
 
 ### `tbl_col` {#spot.tbl_col}
 
@@ -570,6 +684,8 @@ The style of the selected column in the table.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="spot.tbl_col" />
+
 ### `tbl_cell` {#spot.tbl_cell}
 
 The style of the selected cell in the table.
@@ -577,6 +693,9 @@ The style of the selected cell in the table.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+
+<DefaultTheme id="spot.tbl_cell" />
 
 ## [notify] {#notify}
 
@@ -588,6 +707,8 @@ Style of the info title.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="notify.title_info" />
+
 ### `title_warn` {#notify.title_warn}
 
 Style of the warning title.
@@ -596,6 +717,8 @@ Style of the warning title.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="notify.title_warn" />
+
 ### `title_error` {#notify.title_error}
 
 Style of the error title.
@@ -603,6 +726,8 @@ Style of the error title.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="notify.title_error" />
 
 ## [pick] {#pick}
 
@@ -614,6 +739,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="pick.border" />
+
 ### `active` {#pick.active}
 
 Selected item style.
@@ -622,6 +749,8 @@ Selected item style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="pick.active" />
+
 ### `inactive` {#pick.inactive}
 
 Unselected item style.
@@ -629,6 +758,9 @@ Unselected item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+
+<DefaultTheme id="pick.inactive" />
 
 ## [input] {#input}
 
@@ -640,6 +772,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="input.border" />
+
 ### `title` {#input.title}
 
 Title style.
@@ -647,6 +781,8 @@ Title style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="input.title" />
 
 ### `value` {#input.value}
 
@@ -656,6 +792,8 @@ Value style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="input.value" />
+
 ### `selected` {#input.selected}
 
 Selected value style.
@@ -663,6 +801,8 @@ Selected value style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="input.selected" />
 
 ## [cmp] {#cmp}
 
@@ -674,6 +814,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="cmp.border" />
+
 ### `active` {#cmp.active}
 
 Selected item style.
@@ -681,6 +823,8 @@ Selected item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="cmp.active" />
 
 ### `inactive` {#cmp.inactive}
 
@@ -690,6 +834,8 @@ Unselected item style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="cmp.inactive" />
+
 ### `icon_file` {#cmp.icon_file}
 
 File icon.
@@ -697,6 +843,8 @@ File icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="cmp.icon_file" />
 
 ### `icon_folder` {#cmp.icon_folder}
 
@@ -706,6 +854,8 @@ Folder icon.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="cmp.icon_folder" />
+
 ### `icon_command` {#cmp.icon_command}
 
 Command icon.
@@ -713,6 +863,8 @@ Command icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="cmp.icon_command" />
 
 ## [tasks] {#tasks}
 
@@ -724,6 +876,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="tasks.border" />
+
 ### `title` {#tasks.title}
 
 Title style.
@@ -732,6 +886,8 @@ Title style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="tasks.title" />
+
 ### `hovered` {#tasks.hovered}
 
 Hovered item style.
@@ -739,6 +895,8 @@ Hovered item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="tasks.hovered" />
 
 ## [help] {#help}
 
@@ -750,6 +908,8 @@ Key column style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="help.on" />
+
 ### `run` {#help.run}
 
 Action column style.
@@ -757,6 +917,8 @@ Action column style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="help.run" />
 
 ### `desc` {#help.desc}
 
@@ -766,6 +928,8 @@ Description column style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="help.desc" />
+
 ### `hovered` {#help.hovered}
 
 Hovered item style.
@@ -773,6 +937,8 @@ Hovered item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="help.hovered" />
 
 ### `footer` {#help.footer}
 
@@ -782,6 +948,8 @@ Footer style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="help.footer" />
+
 ### `icon_info` {#help.icon_info}
 
 Info icon.
@@ -789,6 +957,8 @@ Info icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="notify.icon_info" />
 
 ### `icon_warn` {#help.icon_warn}
 
@@ -798,6 +968,8 @@ Warning icon.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="notify.icon_warn" />
+
 ### `icon_error` {#help.icon_error}
 
 Error icon.
@@ -805,6 +977,8 @@ Error icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="notify.icon_error" />
 
 ## [filetype] {#filetype}
 
@@ -842,6 +1016,8 @@ You can restrict the specific type of files through `is`, noting that it must be
 - `orphan`: Orphan symbolic link
 - `sock`: Socket
 - `sticky`: File with sticky bit set
+
+<DefaultTheme id="filetype" />
 
 ## [icon] {#icon}
 
@@ -919,3 +1095,5 @@ prepend_conds = [
 	{ if = "!(dir | link)", text = "📄" },  # Normal files (not directories or symlinks)
 ]
 ```
+<DefaultTheme id="icon" raw={true}/>
+

--- a/docs/configuration/yazi.md
+++ b/docs/configuration/yazi.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 description: Learn how to configure Yazi's basic functionality.
 ---
+import Default, {Defaults} from "@site/src/components/Default";
 
 # yazi.toml
 
@@ -19,6 +20,8 @@ Manager layout by ratio, 3-element array. For example:
 
 Set the value to `0` to hide the corresponding panel, but at least one panel must be visible (non-zero).
 
+<Default id="mgr.ratio"/>
+
 ### `sort_by` {#mgr.sort_by}
 
 File sorting method.
@@ -32,12 +35,16 @@ File sorting method.
 - `"size"`: Sort by file size.
 - `"random"`: Sort randomly.
 
+<Default id="mgr.sort_by"/>
+
 ### `sort_sensitive` {#mgr.sort_sensitive}
 
 Sort case-sensitively.
 
 - `true`: Case-sensitive
 - `false`: Case-insensitive
+
+<Default id="mgr.sort_sensitive"/>
 
 ### `sort_reverse` {#mgr.sort_reverse}
 
@@ -46,12 +53,16 @@ Display files in reverse order.
 - `true`: Reverse order
 - `false`: Normal order
 
+<Default id="mgr.sort_reverse"/>
+
 ### `sort_dir_first` {#mgr.sort_dir_first}
 
 Display directories first.
 
 - `true`: Directories first
 - `false`: Normal order
+
+<Default id="mgr.sort_dir_first"/>
 
 ### `sort_translit` {#mgr.sort_translit}
 
@@ -61,6 +72,8 @@ This is useful for files that contain Hungarian characters.
 
 - `true`: Enabled
 - `false`: Disabled
+
+<Default id="mgr.sort_translit"/>
 
 ### `linemode` {#mgr.linemode}
 
@@ -98,12 +111,16 @@ function Linemode:size_and_mtime()
 end
 ```
 
+<Default id="mgr.linemode"/>
+
 ### `show_hidden` {#mgr.show_hidden}
 
 Show hidden files.
 
 - `true`: Show
 - `false`: Do not show
+
+<Default id="mgr.show_hidden"/>
 
 ### `show_symlink` {#mgr.show_symlink}
 
@@ -112,11 +129,15 @@ Show the path that the symlink points to after the filename.
 - `true`: Show
 - `false`: Do not show
 
+<Default id="mgr.show_symlink"/>
+
 ### `scrolloff` {#mgr.scrolloff}
 
 The number of files to keep above and below the cursor when moving through the file list.
 
 If the value is larger than half the screen height (e.g. `200`), the cursor will be centered.
+
+<Default id="mgr.scrolloff"/>
 
 ### `mouse_events` {#mgr.mouse_events}
 
@@ -132,6 +153,8 @@ If the array is empty, disable the mouse.
 
 Usually, you don't need to change it, unless the plugin you're using requires enabling a certain event.
 
+<Default id="mgr.mouse_events"/>
+
 ## [preview] {#preview}
 
 ### `wrap` {#preview.wrap}
@@ -141,21 +164,29 @@ Wrap long lines in the code preview.
 - `"yes"`: Enable word wrap
 - `"no"`: Disable word wrap
 
+<Default id="preview.wrap"/>
+
 ### `tab_size` {#preview.tab_size}
 
 The width of a tab character (`\t`) in spaces.
 
+<Default id="preview.tab_size"/>
+
 ### `max_width` {#preview.max_width}
 
-Maximum preview width for images. Run `ya cache clear` after changing this for it to take effect.
+Maximum preview width for images. Run `yazi --clear-cache` after changing this for it to take effect.
 
 This value is also used for preloading images; the larger it is, the larger the image cache generated, which consumes more CPU.
+
+<Default id="preview.max_width"/>
 
 ### `max_height` {#preview.max_height}
 
-Maximum preview height for images. Run `ya cache clear` after changing this for it to take effect.
+Maximum preview height for images. Run `yazi --clear-cache` after changing this for it to take effect.
 
 This value is also used for preloading images; the larger it is, the larger the image cache generated, which consumes more CPU.
+
+<Default id="preview.max_height"/>
 
 ### `cache_dir` {#preview.cache_dir}
 
@@ -171,6 +202,8 @@ This is to alleviate lag caused by some terminal emulators struggling to render 
 
 See https://github.com/sxyazi/yazi/pull/1512 for more information.
 
+<Default id="preview.image_delay"/>
+
 ### `image_filter` {#preview.image_filter}
 
 The filter used on image downscaling, available values:
@@ -184,11 +217,15 @@ They are arranged in order from fast to slow, and from poor to good quality - La
 
 See the example and benchmark here: https://docs.rs/image/0.24.8/image/imageops/enum.FilterType.html#examples
 
+<Default id="preview.image_filter"/>
+
 ### `image_quality` {#preview.image_quality}
 
 Quality on pre-caching images, range 50-90.
 
 The larger value, the better image quality, but slower with more CPU consumption, and generates larger cache files that occupy more storage space.
+
+<Default id="preview.image_quality"/>
 
 ### `ueberzug_scale` / `ueberzug_offset` {#preview.ueberzug_scale}
 
@@ -198,6 +235,9 @@ The larger value, the better image quality, but slower with more CPU consumption
 This is useful for solving [a bug of Überzug++ image size calculation](https://github.com/jstkdng/ueberzugpp/issues/122).
 
 If your monitor has a `2.0` scale factor, and is running on Wayland under Hyprland, you may need to set `ueberzug_scale: 0.5`, and adjust the value of `ueberzug_offset` according to your case, to offset this issue.
+
+<Default id="preview.ueberzug_scale" show_key="ueberzug_scale"/>
+<Default id="preview.ueberzug_offset" show_key="ueberzug_offset"/>
 
 ## [opener] {#opener}
 
@@ -235,6 +275,9 @@ Available options are as follows:
 - `orphan`: Keep the process running even if Yazi has exited, once specified, the process will be detached from the task scheduling system.
 - `desc`: Description of the opener, display in interactive components, such as "Open with" and help menu.
 - `for`: The opener is only available on this system, similar to [per-OS keybindings](/docs/configuration/keymap#per-os).
+
+
+<Default id="opener" raw={true}/>
 
 ## [open] {#open}
 
@@ -282,39 +325,57 @@ With that:
 - You can [`spot`](/docs/configuration/keymap#mgr.spot) on a file to check it's mime-type with the default <kbd>Tab</kbd> key.
 - If `use` is an array containing multiple openers, all commands in these openers will be merged. [`open`](/docs/configuration/keymap#mgr.open) will run the first of these commands; [`open --interactive`](/docs/configuration/keymap#mgr.open) will list all of these commands in the "open with" menu.
 
+<Default id="open" raw={true} />
+
 ## [tasks] {#tasks}
 
 ### `file_workers` {#tasks.file_workers}
 
 Max concurrent file operations, such as copy, cut, delete, etc.
 
+<Default id="tasks.file_workers"/>
+
 ### `plugin_workers` {#tasks.plugin_workers}
 
 Max concurrent functional-plugin tasks.
+
+<Default id="tasks.plugin_workers"/>
 
 ### `fetch_workers` {#tasks.fetch_workers}
 
 Max concurrent fetch tasks.
 
+<Default id="tasks.fetch_workers"/>
+
 ### `preload_workers` {#tasks.preload_workers}
 
 Max concurrent preload tasks.
+
+<Default id="tasks.preload_workers"/>
 
 ### `process_workers` {#tasks.process_workers}
 
 Max concurrent processes.
 
+<Default id="tasks.process_workers"/>
+
 ### `bizarre_retry` {#tasks.bizarre_retry}
 
 Maximum number of retries when a bizarre failure occurs.
+
+<Default id="tasks.bizarre_retry"/>
 
 ### `suppress_preload` {#tasks.suppress_preload}
 
 Exclude the preload tasks created by the system from the task list, do not report their progress, and do not consider them on app exit confirming.
 
+<Default id="tasks.suppress_preload"/>
+
 ### `image_alloc` {#tasks.image_alloc}
 
 Maximum memory allocation limit in bytes for decoding a single image, `0` for unlimited.
+
+<Default id="tasks.image_alloc"/>
 
 ### `image_bound` {#tasks.image_bound}
 
@@ -338,6 +399,8 @@ Here are the available options for a single rule:
 - `if`: Run the fetcher only if the condition is met.
 - `prio`: Task scheduling priority. One of `high`, `normal` or `low`.
 - `group`: Group of the fetcher. Only the first matching fetcher in the same group will be run.
+
+<Default id="plugin.fetchers" raw={true}/>
 
 ### previewers {#plugin.previewers}
 
@@ -378,6 +441,8 @@ Yazi comes with these previewer plugins:
 
 If you want to create your own previewer, see [Previewer API](/docs/plugins/overview#previewer).
 
+<Default id="plugin.previewers" raw={true} />
+
 ### preloaders {#plugin.preloaders}
 
 You can prepend or append new preview rules to the default `preloaders` under `[plugin]` by `prepend_preloaders` and `append_preloaders`, see [Configuration mixing](/docs/configuration/overview#mixing) for details.
@@ -406,6 +471,8 @@ Yazi comes with these preloader plugins:
 
 If you want to create your own preloader, see [Preloader API](/docs/plugins/overview#preloader).
 
+<Default id="plugin.preloaders" raw={true}/>
+
 ## [input] {#input}
 
 ### `cursor_blink` {#input.cursor_blink}
@@ -420,13 +487,19 @@ You can customize the title and position of each input. The following inputs are
 As for position, it consists of two parts: [Origin](#input.origin) and [Offset](#input.offset).
 The origin is the top-left corner of the input, and the offset is the increment from this origin. Together, they determine the area of the input on the screen.
 
+<Default id="input.cursor_blink"/>
+
 ### Origin {#input.origin}
 
 See [`Origin`](/docs/plugins/aliases#origin) for available values.
 
+<Defaults section="input" searchKey="origin" />
+
 ### Offset {#input.offset}
 
 As for the offset, it's a 4-element tuple: `(x, y, width, height)`.
+
+<Defaults section="input" searchKey="offset" />
 
 ### Placeholder {#input.placeholder}
 
@@ -434,39 +507,50 @@ Some inputs have special placeholders that will be replaced with actual content 
 
 - cd_title: String
 
-  Title of the [`cd --interactive`](/docs/configuration/keymap/#mgr.cd) input used to enter the target path.
+  - Title of the [`cd --interactive`](/docs/configuration/keymap/#mgr.cd) input used to enter the target path.
+  - <Default id="input.cd_title"/>
 
 - create_title: [String, String]
 
-  It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` action.
+  - It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` action.
+  - <Default id="input.create_title"/>
+
 
 - rename_title: String
 
-  Title of the [`rename`](/docs/configuration/keymap/#mgr.rename) input used to enter the new name.
+  - Title of the [`rename`](/docs/configuration/keymap/#mgr.rename) input used to enter the new name.
+  - <Default id="input.rename_title"/>
 
 - filter_title: String
 
-  Title of the [`filter`](/docs/configuration/keymap/#mgr.filter) input used to enter the keyword.
+  - Title of the [`filter`](/docs/configuration/keymap/#mgr.filter) input used to enter the keyword.
+  - <Default id="input.filter_title"/>
+
 
 - find_title: [String, String]
 
-  It's a tuple of 2-element: first for [`find`](/docs/configuration/keymap/#mgr.find), second for `find --previous`.
+  - It's a tuple of 2-element: first for [`find`](/docs/configuration/keymap/#mgr.find), second for `find --previous`. 
+  - <Default id="input.find_title"/>
 
 - search_title: String
 
   - `{n}`: Name of the current [`search`](/docs/configuration/keymap/#mgr.search) engine.
+  - <Default id="input.search_title"/>
 
 - shell_title: [String, String]
 
-  It's a tuple of 2-element: first for [`shell --interactive`](/docs/configuration/keymap/#mgr.shell), second for `shell --interactive --block`.
+  - It's a tuple of 2-element: first for [`shell --interactive`](/docs/configuration/keymap/#mgr.shell), second for `shell --interactive --block`.
+  - <Default id="input.shell_title"/>
 
 ## [confirm] {#confirm}
 
 Same as the [`[input]`](#input) section. There are a few available: `trash`, `delete`, `overwrite` and `quit`.
+<Default id="confirm" raw={true}/>
 
 ## [pick] {#pick}
 
 Same as the [`[input]`](#input) section. Available selectors: `open`.
+<Default id="pick" raw={true}/>
 
 ## [which] {#which}
 
@@ -478,6 +562,8 @@ Candidate sorting method.
 - `"key"`: Sort by key.
 - `"desc`: Sort by description.
 
+<Default id="which.sort_by"/>
+
 ### `sort_sensitive` {#which.sort_sensitive}
 
 Sort case-sensitively.
@@ -485,12 +571,17 @@ Sort case-sensitively.
 - `true`: Case-sensitive
 - `false`: Case-insensitive
 
+<Default id="which.sort_sensitive"/>
+
 ### `sort_reverse` {#which.sort_reverse}
 
 Display candidates in reverse order.
 
 - `true`: Reverse order
 - `false`: Normal order
+
+<Default id="which.sort_reverse"/>
+
 
 ### `sort_translit` {#which.sort_translit}
 
@@ -500,3 +591,5 @@ This is useful for files that contain Hungarian characters.
 
 - `true`: Enabled
 - `false`: Disabled
+
+<Default id="which.sort_translit"/>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"write-translations": "docusaurus write-translations",
 		"write-heading-ids": "docusaurus write-heading-ids",
 		"typecheck": "tsc",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"defaults": "node ./scripts/defaults.js"
 	},
 	"dependencies": {
 		"@docusaurus/core": "3.10.1",
@@ -19,13 +20,16 @@
 		"@mdx-js/react": "^3.1.0",
 		"clsx": "^1.2.1",
 		"prism-react-renderer": "^2.4.1",
+		"raw-loader": "^4.0.2",
 		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react-dom": "^18.3.1",
+		"toml": "^5.0.0"
 	},
 	"devDependencies": {
 		"@docusaurus/module-type-aliases": "3.10.1",
 		"@docusaurus/tsconfig": "3.10.1",
 		"@docusaurus/types": "3.10.1",
+		"@types/react": "^19.2.17",
 		"prettier": "^3.5.3",
 		"typescript": "~5.2.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,25 +10,31 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.10.1
-        version: 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+        version: 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/preset-classic':
         specifier: 3.10.1
-        version: 3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)
+        version: 3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)
       '@mdx-js/react':
         specifier: ^3.1.0
-        version: 3.1.0(@types/react@19.1.0)(react@18.3.1)
+        version: 3.1.0(@types/react@19.2.17)(react@18.3.1)
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@18.3.1)
+      raw-loader:
+        specifier: ^4.0.2
+        version: 4.0.2(webpack@5.98.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      toml:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.1
@@ -39,6 +45,9 @@ importers:
       '@docusaurus/types':
         specifier: 3.10.1
         version: 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -1494,8 +1503,8 @@ packages:
   '@types/react-router@5.1.20':
     resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
-  '@types/react@19.1.0':
-    resolution: {integrity: sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -2148,8 +2157,8 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -4061,6 +4070,12 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
+  raw-loader@4.0.2:
+    resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -4575,6 +4590,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  toml@5.0.0:
+    resolution: {integrity: sha512-bsqEd+g7fzlrw7LEynQ6W6aOK/lTOlepz5x1sJyIV9fTZVJS2Q76nuju6FK+gZhW5bUpvB7mCEqdR0u4WziMFw==}
+    engines: {node: '>=20'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -6018,14 +6037,14 @@ snapshots:
 
   '@docsearch/css@3.9.0': {}
 
-  '@docsearch/react@3.9.0(@algolia/client-search@5.40.1)(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)':
+  '@docsearch/react@3.9.0(@algolia/client-search@5.40.1)(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.40.1)(algoliasearch@5.40.1)(search-insights@2.9.0)
       '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.40.1)(algoliasearch@5.40.1)
       '@docsearch/css': 3.9.0
       algoliasearch: 5.40.1
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       search-insights: 2.9.0
@@ -6100,7 +6119,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/core@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
       '@docusaurus/babel': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/bundler': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
@@ -6109,7 +6128,7 @@ snapshots:
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mdx-js/react': 3.1.0(@types/react@19.1.0)(react@18.3.1)
+      '@mdx-js/react': 3.1.0(@types/react@19.2.17)(react@18.3.1)
       boxen: 6.2.1
       chalk: 4.1.2
       chokidar: 3.6.0
@@ -6216,7 +6235,7 @@ snapshots:
     dependencies:
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 18.3.1
@@ -6231,13 +6250,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.10.1
       '@docusaurus/mdx-loader': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6274,13 +6293,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.10.1
       '@docusaurus/mdx-loader': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6315,9 +6334,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-pages@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/mdx-loader': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6346,9 +6365,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6374,9 +6393,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-debug@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.0
@@ -6403,9 +6422,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-analytics@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -6430,9 +6449,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-gtag@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/gtag.js': 0.0.20
@@ -6458,9 +6477,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-tag-manager@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -6485,9 +6504,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-sitemap@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.10.1
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6517,9 +6536,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-svgr@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6548,22 +6567,22 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)':
+  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-debug': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-analytics': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-gtag': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-tag-manager': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-sitemap': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-svgr': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-classic': 3.10.1(@types/react@19.1.0)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-debug': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-analytics': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-gtag': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-tag-manager': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-sitemap': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-svgr': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-classic': 3.10.1(@types/react@19.2.17)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -6591,25 +6610,25 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@18.3.1)':
     dependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.10.1(@types/react@19.1.0)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/theme-classic@3.10.1(@types/react@19.2.17)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.10.1
       '@docusaurus/mdx-loader': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.10.1
       '@docusaurus/types': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mdx-js/react': 3.1.0(@types/react@19.1.0)(react@18.3.1)
+      '@mdx-js/react': 3.1.0(@types/react@19.2.17)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
       infima: 0.2.0-alpha.45
@@ -6643,15 +6662,15 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/mdx-loader': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       '@types/react-router-config': 5.0.11
       clsx: 2.1.1
       parse-numeric-range: 1.3.0
@@ -6668,14 +6687,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)':
+  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)(typescript@5.2.2)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.8(@algolia/client-search@5.40.1)(algoliasearch@5.40.1)(search-insights@2.9.0)
-      '@docsearch/react': 3.9.0(@algolia/client-search@5.40.1)(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docsearch/react': 3.9.0(@algolia/client-search@5.40.1)(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.9.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.10.1
       '@docusaurus/utils': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.1(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6723,7 +6742,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@types/history': 4.7.11
       '@types/mdast': 4.0.4
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       commander: 5.1.0
       joi: 17.13.3
       react: 18.3.1
@@ -6916,10 +6935,10 @@ snapshots:
       - acorn
       - supports-color
 
-  '@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1)':
+  '@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       react: 18.3.1
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7195,23 +7214,23 @@ snapshots:
   '@types/react-router-config@5.0.11':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       '@types/react-router': 5.1.20
 
   '@types/react-router-dom@5.3.3':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
       '@types/react-router': 5.1.20
 
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.0
+      '@types/react': 19.2.17
 
-  '@types/react@19.1.0':
+  '@types/react@19.2.17':
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/retry@0.12.2': {}
 
@@ -7948,7 +7967,7 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   debounce@1.2.1: {}
 
@@ -10207,6 +10226,12 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  raw-loader@4.0.2(webpack@5.98.0):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.98.0
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -10840,6 +10865,8 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  toml@5.0.0: {}
 
   totalist@3.0.1: {}
 

--- a/scripts/defaults.js
+++ b/scripts/defaults.js
@@ -1,0 +1,18 @@
+import { writeFile } from "fs/promises";
+import versions from "../versions.json" with {type: "json"};
+import {join} from "path";
+
+const stable = versions[0];
+const URL_BASE = `https://raw.githubusercontent.com/sxyazi/yazi/refs/tags/v${stable}/yazi-config/preset/`;
+
+for (const file of [
+	"yazi-default.toml",
+	"theme-light.toml",
+	"theme-dark.toml",
+	"keymap-default.toml"
+]) {
+	const target = join(import.meta.dirname, "../src/components/Default/", file);
+	const contents = await (await fetch(URL_BASE + file)).text();
+	writeFile(target, contents, {encoding: "utf-8"})
+}
+

--- a/src/components/Default/index.tsx
+++ b/src/components/Default/index.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import CodeBlock from '@theme/CodeBlock';
+import {useLocation} from "@docusaurus/router";
+import {parse} from "toml";
+
+import yazi from "!!raw-loader!./yazi-default.toml";
+import keymap from "!!raw-loader!./keymap-default.toml";
+import themeLight from "raw-loader!./theme-light.toml";
+import themeDark from "raw-loader!./theme-dark.toml";
+
+function getRelevantSettingsFile() {
+        switch (useLocation().pathname) {
+                case "/docs/configuration/yazi":
+                        return yazi;
+                case "/docs/configuration/keymap":
+                        return keymap;
+                
+        }
+
+}
+
+function getDefaultAsCodeblock(data: object, section: string, key?: string) {
+        // Get default value & stringify
+        const rawData = key ? data[section][key] : data[section];
+        const value = JSON.stringify(rawData);
+        return (
+                <code>{value}</code>
+        )
+}
+
+// For raw=true
+function _getRawtoml(defaultFileString: string, regex: RegExp, cb: (val: string) => string) {
+        const toml = cb(defaultFileString.match(regex)[0])
+        parse(toml)  // Sanity check
+        return toml;
+}
+
+function getRawtoml(defaultFileString: string, section: string, key?: string, sectionRegexEnd:string="(^\\[|$(?![\\r\\n]))", keyRegexEnd="\]") {
+        // return "\\[" + section + "\\](.|\\n)*?" + sectionRegexEnd
+        const sectionToml = _getRawtoml(
+                defaultFileString,
+                new RegExp("\\[" + section + "\\](.|\n)*?" + sectionRegexEnd, "gm"),
+                (val) => val.replace(/\]$\n\n^\[/m, "]")
+        );
+        if (!key) { return sectionToml; }
+        else {
+                return _getRawtoml(
+                        sectionToml,
+                        new RegExp(key + "(.|\n)*?" + keyRegexEnd, "gm"),
+                        (val) => val)
+        }
+}
+
+export function Defaults({section, searchKey}: {section: string, searchKey: string}) {
+        const data = parse(getRelevantSettingsFile());
+
+        const sectionSettings = data[section]
+        const relevantSettings = Object.keys(sectionSettings).filter(setting => setting.includes(searchKey));
+        const elements = relevantSettings.map(key => {
+                return (
+                        <li>
+                                {key} = {getDefaultAsCodeblock(data, section, key)}
+                        </li>
+                )
+        });
+        return (
+                <section class="default">
+                        <p>Default values including <code>{searchKey}</code>:</p>
+                        <ul>
+                                {elements}
+                        </ul>
+                </section>
+        )
+}
+
+export function DefaultWithProp({id, prop, value, regex, remove}: {id: string, prop:string, value: string, regex?:string, remove?:string}) {
+        const [section, key] = id.split(".", 2);  // Get section & key
+        const parsedRegex = new RegExp(regex || `.*${value}.*`)
+
+        const data = parse(getRelevantSettingsFile())[section][key]  // TODO cleaner remove implementation
+                .filter(obj => parsedRegex.test(obj[prop]) && !JSON.stringify(obj[prop]).includes(remove))
+                .map(obj => (
+                        <li>
+                                On <code>{obj.on}</code> pressed,
+                                run <code>{JSON.stringify(obj.run)}</code>
+                                <br/>({obj.desc})
+                        </li>
+                ))
+        if (data.length >= 1) {
+                return ( <ul>{data}</ul> );
+        } else {
+                const dataFor = `${id} = [ { ${prop} = "${value}" } ]`
+                return ( <p>No default is configured with <code>{dataFor}</code></p> )
+        }
+
+}
+
+export default function Default({
+        id, show_key,
+        raw=false,
+        asList=false,
+        sectionRegexEnd=undefined,
+        keyRegexEnd="\]", // TODO fix filetype/theme raw multiline output
+        relevantFile=getRelevantSettingsFile(),
+        ...props}: {
+                id: string,
+                show_key?: string,
+                raw?: boolean,
+                asList?: boolean,
+                sectionRegexEnd?: string,
+                keyRegexEnd?: string,
+                relevantFile?: string,
+                children?: any
+        }) {
+        const data = parse(relevantFile);
+        const [section, key] = id.split(".", 2);  // Get section & key
+
+        // Optionally add "for {key}" to output
+        const p = `Default value ${show_key ? `for ${show_key}` : ""} is`
+
+        if (!raw) {
+                return (
+                        <p className="default" {...props}>{p} {getDefaultAsCodeblock(data, section, key)}</p>
+                )
+        } else {
+                return (
+                        <section className="default">
+                                <p {...props}>{p}:</p>
+                                <CodeBlock language="toml">
+                                        {getRawtoml(relevantFile, section, key, sectionRegexEnd, keyRegexEnd)}
+                                </CodeBlock>
+                        </section>
+
+                )
+        }
+}
+
+const SECTION_REGEXEND = "^\]";
+const KEY_REGEXEND = "$"
+export function DefaultTheme({id, ...props}) {
+        const [section,key] = id.split(".", 2);
+
+        const values = [themeDark, themeLight].map(theme => {
+                const parsed = parse(theme);
+                const value = key ? parsed[section][key] : parsed[section]
+
+                return JSON.stringify(value);
+        })
+        
+        if (values[0] == values[1]) {
+                return (
+                        <Default id={id} raw={true} keyRegexEnd="$" sectionRegexEnd={SECTION_REGEXEND} show_key="both themes" relevantFile={themeLight} {...props}/>
+                )
+        } else {
+                return (
+                        <section className="default">
+                                <Default keyRegexEnd="$" id={id} raw={true} sectionRegexEnd={SECTION_REGEXEND} show_key="the light theme" relevantFile={themeLight} {...props} />
+                                <Default keyRegexEnd="$" id={id} raw={true} sectionRegexEnd={SECTION_REGEXEND} show_key="the dark theme" relevantFile={themeDark} {...props}/>
+                        </section>
+                )
+        }
+        
+}
+
+

--- a/src/components/Default/keymap-default.toml
+++ b/src/components/Default/keymap-default.toml
@@ -1,0 +1,375 @@
+# A TOML linter such as https://github.com/tombi-toml/tombi can use this schema to validate your config.
+# If you encounter any problems, please make an issue at https://github.com/yazi-rs/schemas.
+
+#:schema https://yazi-rs.github.io/schemas/keymap.json
+
+[mgr]
+
+keymap = [
+	{ on = "<Esc>", run = "escape",             desc = "Exit visual mode, clear selection, or cancel search" },
+	{ on = "<C-[>", run = "escape",             desc = "Exit visual mode, clear selection, or cancel search" },
+	{ on = "q",     run = "quit",               desc = "Quit the process" },
+	{ on = "Q",     run = "quit --no-cwd-file", desc = "Quit without outputting cwd-file" },
+	{ on = "<C-c>", run = "close",              desc = "Close the current tab, or quit if it's last" },
+	{ on = "<C-z>", run = "suspend",            desc = "Suspend the process" },
+
+	# Hopping
+	{ on = "k", run = "arrow prev", desc = "Previous file" },
+	{ on = "j", run = "arrow next", desc = "Next file" },
+
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous file" },
+	{ on = "<Down>", run = "arrow next", desc = "Next file" },
+
+	{ on = "<C-u>", run = "arrow -50%",  desc = "Move cursor up half page" },
+	{ on = "<C-d>", run = "arrow 50%",   desc = "Move cursor down half page" },
+	{ on = "<C-b>", run = "arrow -100%", desc = "Move cursor up one page" },
+	{ on = "<C-f>", run = "arrow 100%",  desc = "Move cursor down one page" },
+
+	{ on = "<S-PageUp>",   run = "arrow -50%",  desc = "Move cursor up half page" },
+	{ on = "<S-PageDown>", run = "arrow 50%",   desc = "Move cursor down half page" },
+	{ on = "<PageUp>",     run = "arrow -100%", desc = "Move cursor up one page" },
+	{ on = "<PageDown>",   run = "arrow 100%",  desc = "Move cursor down one page" },
+
+	{ on = [ "g", "g" ], run = "arrow top", desc = "Go to top" },
+	{ on = "G",          run = "arrow bot", desc = "Go to bottom" },
+
+	# Navigation
+	{ on = "h", run = "leave", desc = "Back to the parent directory" },
+	{ on = "l", run = "enter", desc = "Enter the child directory" },
+
+	{ on = "<Left>",  run = "leave", desc = "Back to the parent directory" },
+	{ on = "<Right>", run = "enter", desc = "Enter the child directory" },
+
+	{ on = "H", run = "back",    desc = "Back to previous directory" },
+	{ on = "L", run = "forward", desc = "Forward to next directory" },
+
+	# Toggle
+	{ on = "<Space>", run = [ "toggle", "arrow 1" ], desc = "Toggle the current selection state" },
+	{ on = "<C-a>",   run = "toggle_all --state=on", desc = "Select all files" },
+	{ on = "<C-r>",   run = "toggle_all",            desc = "Invert selection of all files" },
+
+	# Visual mode
+	{ on = "v", run = "visual_mode",         desc = "Enter visual mode (selection mode)" },
+	{ on = "V", run = "visual_mode --unset", desc = "Enter visual mode (unset mode)" },
+
+	# Seeking
+	{ on = "K", run = "seek -5", desc = "Seek up 5 units in the preview" },
+	{ on = "J", run = "seek 5",  desc = "Seek down 5 units in the preview" },
+
+	# Spotting
+	{ on = "<Tab>", run = "spot", desc = "Spot hovered file" },
+
+	# Operation
+	{ on = "o",         run = "open",                        desc = "Open selected files" },
+	{ on = "O",         run = "open --interactive",          desc = "Open selected files interactively" },
+	{ on = "<Enter>",   run = "open",                        desc = "Open selected files" },
+	{ on = "<S-Enter>", run = "open --interactive",          desc = "Open selected files interactively" },
+	{ on = "y",         run = "yank",                        desc = "Yank selected files (copy)" },
+	{ on = "x",         run = "yank --cut",                  desc = "Yank selected files (cut)" },
+	{ on = "p",         run = "paste",                       desc = "Paste yanked files" },
+	{ on = "P",         run = "paste --force",               desc = "Paste yanked files (overwrite if the destination exists)" },
+	{ on = "-",         run = "link",                        desc = "Symlink the absolute path of yanked files" },
+	{ on = "_",         run = "link --relative",             desc = "Symlink the relative path of yanked files" },
+	{ on = "<C-->",     run = "hardlink",                    desc = "Hardlink yanked files" },
+	{ on = "Y",         run = "unyank",                      desc = "Cancel the yank status" },
+	{ on = "X",         run = "unyank",                      desc = "Cancel the yank status" },
+	{ on = "d",         run = "remove",                      desc = "Trash selected files" },
+	{ on = "D",         run = "remove --permanently",        desc = "Permanently delete selected files" },
+	{ on = "a",         run = "create",                      desc = "Create a file (ends with / for directories)" },
+	{ on = "r",         run = "rename --cursor=before_ext",  desc = "Rename selected file(s)" },
+	{ on = ";",         run = "shell --interactive",         desc = "Run a shell command" },
+	{ on = ":",         run = "shell --block --interactive", desc = "Run a shell command (block until finishes)" },
+	{ on = ".",         run = "hidden toggle",               desc = "Toggle the visibility of hidden files" },
+	{ on = "s",         run = "search --via=fd",             desc = "Search files by name via fd" },
+	{ on = "S",         run = "search --via=rg",             desc = "Search files by content via ripgrep" },
+	{ on = "<C-s>",     run = "escape --search",             desc = "Cancel the ongoing search" },
+	{ on = "z",         run = "plugin fzf",                  desc = "Jump to a file/directory via fzf" },
+	{ on = "Z",         run = "plugin zoxide",               desc = "Jump to a directory via zoxide" },
+
+	# Linemode
+	{ on = [ "m", "s" ], run = "linemode size",        desc = "Linemode: size" },
+	{ on = [ "m", "p" ], run = "linemode permissions", desc = "Linemode: permissions" },
+	{ on = [ "m", "b" ], run = "linemode btime",       desc = "Linemode: btime" },
+	{ on = [ "m", "m" ], run = "linemode mtime",       desc = "Linemode: mtime" },
+	{ on = [ "m", "o" ], run = "linemode owner",       desc = "Linemode: owner" },
+	{ on = [ "m", "n" ], run = "linemode none",        desc = "Linemode: none" },
+
+	# Copy
+	{ on = [ "c", "c" ], run = "copy path",             desc = "Copy file URL" },
+	{ on = [ "c", "d" ], run = "copy dirname",          desc = "Copy directory URL" },
+	{ on = [ "c", "f" ], run = "copy filename",         desc = "Copy filename" },
+	{ on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy filename without extension" },
+
+	# Filter
+	{ on = "f", run = "filter --smart", desc = "Filter files" },
+
+	# Find
+	{ on = "/", run = "find --smart",            desc = "Find next file" },
+	{ on = "?", run = "find --previous --smart", desc = "Find previous file" },
+	{ on = "n", run = "find_arrow",              desc = "Next found" },
+	{ on = "N", run = "find_arrow --previous",   desc = "Previous found" },
+
+	# Sorting
+	{ on = [ ",", "m" ], run = [ "sort mtime --reverse=no", "linemode mtime" ],  desc = "Sort by modified time" },
+	{ on = [ ",", "M" ], run = [ "sort mtime --reverse=yes", "linemode mtime" ], desc = "Sort by modified time (reverse)" },
+	{ on = [ ",", "b" ], run = [ "sort btime --reverse=no", "linemode btime" ],  desc = "Sort by birth time" },
+	{ on = [ ",", "B" ], run = [ "sort btime --reverse=yes", "linemode btime" ], desc = "Sort by birth time (reverse)" },
+	{ on = [ ",", "e" ], run = "sort extension --reverse=no",                    desc = "Sort by extension" },
+	{ on = [ ",", "E" ], run = "sort extension --reverse=yes",                   desc = "Sort by extension (reverse)" },
+	{ on = [ ",", "a" ], run = "sort alphabetical --reverse=no",                 desc = "Sort alphabetically" },
+	{ on = [ ",", "A" ], run = "sort alphabetical --reverse=yes",                desc = "Sort alphabetically (reverse)" },
+	{ on = [ ",", "n" ], run = "sort natural --reverse=no",                      desc = "Sort naturally" },
+	{ on = [ ",", "N" ], run = "sort natural --reverse=yes",                     desc = "Sort naturally (reverse)" },
+	{ on = [ ",", "s" ], run = [ "sort size --reverse=no", "linemode size" ],    desc = "Sort by size" },
+	{ on = [ ",", "S" ], run = [ "sort size --reverse=yes", "linemode size" ],   desc = "Sort by size (reverse)" },
+	{ on = [ ",", "r" ], run = "sort random --reverse=no",                       desc = "Sort randomly" },
+
+	# Goto
+	{ on = [ "g", "h" ],       run = "cd ~",             desc = "Go home" },
+	{ on = [ "g", "c" ],       run = "cd ~/.config",     desc = "Go ~/.config" },
+	{ on = [ "g", "d" ],       run = "cd ~/Downloads",   desc = "Go ~/Downloads" },
+	{ on = [ "g", "<Space>" ], run = "cd --interactive", desc = "Jump interactively" },
+	{ on = [ "g", "f" ],       run = "follow",           desc = "Follow hovered symlink" },
+
+	# Tabs
+	{ on = [ "t", "t" ], run = "tab_create --current",     desc = "Create a new tab in CWD" },
+	{ on = [ "t", "r" ], run = "tab_rename --interactive", desc = "Rename current tab" },
+
+	{ on = "1", run = "tab_switch 0", desc = "Switch to first tab" },
+	{ on = "2", run = "tab_switch 1", desc = "Switch to second tab" },
+	{ on = "3", run = "tab_switch 2", desc = "Switch to third tab" },
+	{ on = "4", run = "tab_switch 3", desc = "Switch to fourth tab" },
+	{ on = "5", run = "tab_switch 4", desc = "Switch to fifth tab" },
+	{ on = "6", run = "tab_switch 5", desc = "Switch to sixth tab" },
+	{ on = "7", run = "tab_switch 6", desc = "Switch to seventh tab" },
+	{ on = "8", run = "tab_switch 7", desc = "Switch to eighth tab" },
+	{ on = "9", run = "tab_switch 8", desc = "Switch to ninth tab" },
+
+	{ on = "[", run = "tab_switch -1 --relative", desc = "Switch to previous tab" },
+	{ on = "]", run = "tab_switch 1 --relative",  desc = "Switch to next tab" },
+
+	{ on = "{", run = "tab_swap -1", desc = "Swap current tab with previous tab" },
+	{ on = "}", run = "tab_swap 1",  desc = "Swap current tab with next tab" },
+
+	# Tasks
+	{ on = "w", run = "tasks:show", desc = "Show task manager" },
+
+	# Help
+	{ on = "~",    run = "help", desc = "Open help" },
+	{ on = "<F1>", run = "help", desc = "Open help" },
+]
+
+[tasks]
+
+keymap = [
+	{ on = "<Esc>", run = "close", desc = "Close task manager" },
+	{ on = "<C-[>", run = "close", desc = "Close task manager" },
+	{ on = "<C-c>", run = "close", desc = "Close task manager" },
+	{ on = "w",     run = "close", desc = "Close task manager" },
+
+	{ on = "k", run = "arrow prev", desc = "Previous task" },
+	{ on = "j", run = "arrow next", desc = "Next task" },
+
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous task" },
+	{ on = "<Down>", run = "arrow next", desc = "Next task" },
+
+	{ on = "<Enter>", run = "inspect", desc = "Inspect the task" },
+	{ on = "x",       run = "cancel",  desc = "Cancel the task" },
+
+	# Help
+	{ on = "~",    run = "help", desc = "Open help" },
+	{ on = "<F1>", run = "help", desc = "Open help" },
+]
+
+[spot]
+
+keymap = [
+	{ on = "<Esc>", run = "close", desc = "Close the spot" },
+	{ on = "<C-[>", run = "close", desc = "Close the spot" },
+	{ on = "<C-c>", run = "close", desc = "Close the spot" },
+	{ on = "<Tab>", run = "close", desc = "Close the spot" },
+
+	{ on = "k", run = "arrow prev", desc = "Previous line" },
+	{ on = "j", run = "arrow next", desc = "Next line" },
+	{ on = "h", run = "swipe prev", desc = "Swipe to previous file" },
+	{ on = "l", run = "swipe next", desc = "Swipe to next file" },
+
+	{ on = "<Up>",    run = "arrow prev", desc = "Previous line" },
+	{ on = "<Down>",  run = "arrow next", desc = "Next line" },
+	{ on = "<Left>",  run = "swipe prev", desc = "Swipe to previous file" },
+	{ on = "<Right>", run = "swipe next", desc = "Swipe to next file" },
+
+	# Copy
+	{ on = [ "c", "c" ], run = "copy cell", desc = "Copy selected cell" },
+
+	# Help
+	{ on = "~",    run = "help", desc = "Open help" },
+	{ on = "<F1>", run = "help", desc = "Open help" },
+]
+
+[pick]
+
+keymap = [
+	{ on = "<Esc>",   run = "close",          desc = "Cancel pick" },
+	{ on = "<C-[>",   run = "close",          desc = "Cancel pick" },
+	{ on = "<C-c>",   run = "close",          desc = "Cancel pick" },
+	{ on = "<Enter>", run = "close --submit", desc = "Submit the pick" },
+
+	{ on = "k", run = "arrow prev", desc = "Previous option" },
+	{ on = "j", run = "arrow next", desc = "Next option" },
+
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous option" },
+	{ on = "<Down>", run = "arrow next", desc = "Next option" },
+
+	# Help
+	{ on = "~",    run = "help", desc = "Open help" },
+	{ on = "<F1>", run = "help", desc = "Open help" },
+]
+
+[input]
+
+keymap = [
+	{ on = "<C-c>",   run = "close",          desc = "Cancel input" },
+	{ on = "<Enter>", run = "close --submit", desc = "Submit input" },
+	{ on = "<Esc>",   run = "escape",         desc = "Back to normal mode, or cancel input" },
+	{ on = "<C-[>",   run = "escape",         desc = "Back to normal mode, or cancel input" },
+
+	# Mode
+	{ on = "i", run = "insert",                          desc = "Enter insert mode" },
+	{ on = "I", run = [ "move first-char", "insert" ],   desc = "Move to the BOL, and enter insert mode" },
+	{ on = "a", run = "insert --append",                 desc = "Enter append mode" },
+	{ on = "A", run = [ "move eol", "insert --append" ], desc = "Move to the EOL, and enter append mode" },
+	{ on = "v", run = "visual",                          desc = "Enter visual mode" },
+	{ on = "r", run = "replace",                         desc = "Replace a single character" },
+
+	# Selection
+	{ on = "V",     run = [ "move bol", "visual", "move eol" ], desc = "Select from BOL to EOL" },
+	{ on = "<C-A>", run = [ "move eol", "visual", "move bol" ], desc = "Select from EOL to BOL" },
+	{ on = "<C-E>", run = [ "move bol", "visual", "move eol" ], desc = "Select from BOL to EOL" },
+
+	# Character-wise movement
+	{ on = "h",       run = "move -1", desc = "Move back a character" },
+	{ on = "l",       run = "move 1",  desc = "Move forward a character" },
+	{ on = "<Left>",  run = "move -1", desc = "Move back a character" },
+	{ on = "<Right>", run = "move 1",  desc = "Move forward a character" },
+	{ on = "<C-b>",   run = "move -1", desc = "Move back a character" },
+	{ on = "<C-f>",   run = "move 1",  desc = "Move forward a character" },
+
+	# Word-wise movement
+	{ on = "b",         run = "backward",                    desc = "Move back to the start of the current or previous word" },
+	{ on = "B",         run = "backward --far",              desc = "Move back to the start of the current or previous WORD" },
+	{ on = "w",         run = "forward",                     desc = "Move forward to the start of the next word" },
+	{ on = "W",         run = "forward --far",               desc = "Move forward to the start of the next WORD" },
+	{ on = "e",         run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
+	{ on = "E",         run = "forward --far --end-of-word", desc = "Move forward to the end of the current or next WORD" },
+	{ on = "<A-b>",     run = "backward",                    desc = "Move back to the start of the current or previous word" },
+	{ on = "<A-f>",     run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
+	{ on = "<C-Left>",  run = "backward",                    desc = "Move back to the start of the current or previous word" },
+	{ on = "<C-Right>", run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
+
+	# Line-wise movement
+	{ on = "0",      run = "move bol",        desc = "Move to the BOL" },
+	{ on = "$",      run = "move eol",        desc = "Move to the EOL" },
+	{ on = "_",      run = "move first-char", desc = "Move to the first non-whitespace character" },
+	{ on = "^",      run = "move first-char", desc = "Move to the first non-whitespace character" },
+	{ on = "<C-a>",  run = "move bol",        desc = "Move to the BOL" },
+	{ on = "<C-e>",  run = "move eol",        desc = "Move to the EOL" },
+	{ on = "<Home>", run = "move bol",        desc = "Move to the BOL" },
+	{ on = "<End>",  run = "move eol",        desc = "Move to the EOL" },
+
+	# Delete
+	{ on = "<Backspace>", run = "backspace",         desc = "Delete the character before the cursor" },
+	{ on = "<Delete>",    run = "backspace --under", desc = "Delete the character under the cursor" },
+	{ on = "<C-h>",       run = "backspace",         desc = "Delete the character before the cursor" },
+	{ on = "<C-d>",       run = "backspace --under", desc = "Delete the character under the cursor" },
+
+	# Kill
+	{ on = "<C-u>",         run = "kill bol",      desc = "Kill backwards to the BOL" },
+	{ on = "<C-k>",         run = "kill eol",      desc = "Kill forwards to the EOL" },
+	{ on = "<C-w>",         run = "kill backward", desc = "Kill backwards to the start of the current word" },
+	{ on = "<A-d>",         run = "kill forward",  desc = "Kill forwards to the end of the current word" },
+	{ on = "<C-Backspace>", run = "kill backward", desc = "Kill backwards to the start of the current word" },
+	{ on = "<C-Delete>",    run = "kill forward",  desc = "Kill forwards to the end of the current word" },
+
+	# Cut/Yank/Paste
+	{ on = "d", run = "delete --cut",                                      desc = "Cut selected characters" },
+	{ on = "D", run = [ "delete --cut", "move eol" ],                      desc = "Cut until EOL" },
+	{ on = "c", run = "delete --cut --insert",                             desc = "Cut selected characters, and enter insert mode" },
+	{ on = "C", run = [ "delete --cut --insert", "move eol" ],             desc = "Cut until EOL, and enter insert mode" },
+	{ on = "s", run = [ "delete --cut --insert", "move 1" ],               desc = "Cut current character, and enter insert mode" },
+	{ on = "S", run = [ "move bol", "delete --cut --insert", "move eol" ], desc = "Cut from BOL until EOL, and enter insert mode" },
+	{ on = "x", run = [ "delete --cut", "move 1 --in-operating" ],         desc = "Cut current character" },
+	{ on = "y", run = "yank",                                              desc = "Copy selected characters" },
+	{ on = "p", run = "paste",                                             desc = "Paste copied characters after the cursor" },
+	{ on = "P", run = "paste --before",                                    desc = "Paste copied characters before the cursor" },
+
+	# Undo/Redo/Casefy
+	{ on = "u",     run = [ "undo", "casefy lower" ], desc = "Undo, or lowercase if in visual mode" },
+	{ on = "U",     run = "casefy upper",             desc = "Uppercase" },
+	{ on = "<C-r>", run = "redo",                     desc = "Redo the last operation" },
+
+	# Help
+	{ on = "~",    run = "help", desc = "Open help" },
+	{ on = "<F1>", run = "help", desc = "Open help" },
+]
+
+[confirm]
+
+keymap = [
+	{ on = "<Esc>",   run = "close",          desc = "Cancel the confirm" },
+	{ on = "<C-[>",   run = "close",          desc = "Cancel the confirm" },
+	{ on = "<C-c>",   run = "close",          desc = "Cancel the confirm" },
+	{ on = "<Enter>", run = "close --submit", desc = "Submit the confirm" },
+
+	{ on = "n", run = "close",          desc = "Cancel the confirm" },
+	{ on = "y", run = "close --submit", desc = "Submit the confirm" },
+
+	{ on = "k", run = "arrow prev", desc = "Previous line" },
+	{ on = "j", run = "arrow next", desc = "Next line" },
+
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous line" },
+	{ on = "<Down>", run = "arrow next", desc = "Next line" },
+
+	# Help
+	{ on = "~",    run = "help", desc = "Open help" },
+	{ on = "<F1>", run = "help", desc = "Open help" },
+]
+
+[cmp]
+
+keymap = [
+	{ on = "<C-c>",   run = "close",                                      desc = "Cancel completion" },
+	{ on = "<Tab>",   run = "close --submit",                             desc = "Submit the completion" },
+	{ on = "<Enter>", run = [ "close --submit", "input:close --submit" ], desc = "Complete and submit the input" },
+
+	{ on = "<A-k>", run = "arrow prev", desc = "Previous item" },
+	{ on = "<A-j>", run = "arrow next", desc = "Next item" },
+
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous item" },
+	{ on = "<Down>", run = "arrow next", desc = "Next item" },
+
+	{ on = "<C-p>", run = "arrow prev", desc = "Previous item" },
+	{ on = "<C-n>", run = "arrow next", desc = "Next item" },
+
+	# Help
+	{ on = "~",    run = "help", desc = "Open help" },
+	{ on = "<F1>", run = "help", desc = "Open help" },
+]
+
+[help]
+
+keymap = [
+	{ on = "<Esc>", run = "escape", desc = "Clear the filter, or hide the help" },
+	{ on = "<C-[>", run = "escape", desc = "Clear the filter, or hide the help" },
+	{ on = "<C-c>", run = "close",  desc = "Hide the help" },
+
+	# Navigation
+	{ on = "k", run = "arrow prev", desc = "Previous line" },
+	{ on = "j", run = "arrow next", desc = "Next line" },
+
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous line" },
+	{ on = "<Down>", run = "arrow next", desc = "Next line" },
+
+	# Filtering
+	{ on = "f", run = "filter", desc = "Filter help items" },
+]

--- a/src/components/Default/theme-dark.toml
+++ b/src/components/Default/theme-dark.toml
@@ -1,0 +1,1006 @@
+# If the user's terminal is in dark mode, Yazi will load `theme-dark.toml` on startup; otherwise, `theme-light.toml`.
+# You can override any parts of them that are not related to the dark/light mode in your own `theme.toml`.
+
+# If you want to dynamically override their content based on dark/light mode, you can specify two different flavors
+# for dark and light modes under `[flavor]`, and do so in those flavors instead.
+
+#:schema https://yazi-rs.github.io/schemas/theme.json
+# vim:fileencoding=utf-8:foldmethod=marker
+
+# : Flavor {{{
+
+[flavor]
+dark  = ""
+light = ""
+
+# : }}}
+
+
+# : App {{{
+
+[app]
+overall = {}
+
+# : }}}
+
+
+# : Manager {{{
+
+[mgr]
+cwd = { fg = "cyan" }
+
+# Find
+find_keyword  = { fg = "yellow", bold = true, italic = true, underline = true }
+find_position = { fg = "magenta", bg = "reset", bold = true, italic = true }
+
+# Symlink
+symlink_target = { italic = true }
+
+# Marker
+marker_copied   = { fg = "lightgreen",  bg = "lightgreen" }
+marker_cut      = { fg = "lightred",    bg = "lightred" }
+marker_marked   = { fg = "lightcyan",   bg = "lightcyan" }
+marker_selected = { fg = "lightyellow", bg = "lightyellow" }
+marker_symbol   = "│"
+
+# Count
+count_copied   = { fg = "white", bg = "green" }
+count_cut      = { fg = "white", bg = "red" }
+count_selected = { fg = "black", bg = "yellow" }
+
+# Border
+border_symbol = "│"
+border_style  = { fg = "gray" }
+
+# Highlighting
+syntect_theme = ""
+
+# : }}}
+
+
+# : Tabs {{{
+
+[tabs]
+active   = { bg = "blue", bold = true }
+inactive = { fg = "blue", bg = "gray" }
+
+# Separator
+sep_inner = { open = "", close = "" }
+sep_outer = { open = "", close = "" }
+
+# : }}}
+
+
+# : Mode {{{
+
+[mode]
+normal_main = { bg = "blue", bold = true }
+normal_alt  = { fg = "blue", bg = "gray" }
+
+# Select mode
+select_main = { bg = "red", bold = true }
+select_alt  = { fg = "red", bg = "gray" }
+
+# Unset mode
+unset_main = { bg = "red", bold = true }
+unset_alt  = { fg = "red", bg = "gray" }
+
+# : }}}
+
+
+# : Indicator of hovered file {{{
+
+[indicator]
+parent  = { reversed = true }
+current = { reversed = true }
+preview = { underline = true }
+padding = { open = "", close = "" }
+
+# : }}}
+
+
+# : Status bar {{{
+
+[status]
+overall   = {}
+sep_left  = { open = "", close = "" }
+sep_right = { open = "", close = "" }
+
+# Permissions
+perm_sep   = { fg = "darkgray" }
+perm_type  = { fg = "green" }
+perm_read  = { fg = "yellow" }
+perm_write = { fg = "red" }
+perm_exec  = { fg = "cyan" }
+
+# Progress
+progress_label  = { bold = true }
+progress_normal = { fg = "green", bg = "black" }
+progress_error  = { fg = "yellow", bg = "red" }
+
+# : }}}
+
+
+# : Which {{{
+
+[which]
+cols            = 3
+mask            = { bg = "black" }
+cand            = { fg = "lightcyan" }
+rest            = { fg = "darkgray" }
+desc            = { fg = "lightmagenta" }
+separator       = "  "
+separator_style = { fg = "darkgray" }
+
+# : }}}
+
+
+# : Confirmation {{{
+
+[confirm]
+border     = { fg = "blue" }
+title      = { fg = "blue" }
+body       = {}
+list       = {}
+btn_yes    = { reversed = true }
+btn_no     = {}
+btn_labels = [ "  [Y]es  ", "  (N)o  " ]
+
+# : }}}
+
+
+# : Spotter {{{
+
+[spot]
+border = { fg = "blue" }
+title  = { fg = "blue" }
+
+# Table
+tbl_col  = { fg = "blue" }
+tbl_cell = { fg = "yellow", reversed = true }
+
+# : }}}
+
+
+# : Notification {{{
+
+[notify]
+title_info  = { fg = "green" }
+title_warn  = { fg = "yellow" }
+title_error = { fg = "red" }
+
+# Icons
+icon_info  = ""
+icon_warn  = ""
+icon_error = ""
+
+# : }}}
+
+
+# : Picker {{{
+
+[pick]
+border   = { fg = "blue" }
+active   = { fg = "magenta", bold = true }
+inactive = {}
+
+# : }}}
+
+
+# : Input {{{
+
+[input]
+border   = { fg = "blue" }
+title    = {}
+value    = {}
+selected = { reversed = true }
+
+# : }}}
+
+
+# : Completion {{{
+
+[cmp]
+border   = { fg = "blue" }
+active   = { reversed = true }
+inactive = {}
+
+# Icons
+icon_file    = ""
+icon_folder  = ""
+icon_command = ""
+
+# : }}}
+
+
+# : Task manager {{{
+
+[tasks]
+border  = { fg = "blue" }
+title   = {}
+hovered = { fg = "magenta", bold = true }
+
+# : }}}
+
+
+# : Help menu {{{
+
+[help]
+on      = { fg = "cyan" }
+run     = { fg = "magenta" }
+desc    = {}
+hovered = { reversed = true, bold = true }
+footer  = { fg = "black", bg = "white" }
+
+# : }}}
+
+
+# : File-specific styles {{{
+
+[filetype]
+rules = [
+	# Image
+	{ mime = "image/*", fg = "yellow" },
+	# Media
+	{ mime = "{audio,video}/*", fg = "magenta" },
+	# Archive
+	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "red" },
+	# Document
+	{ mime = "application/{pdf,doc,rtf}", fg = "cyan" },
+	# Virtual file system
+	{ mime = "vfs/{absent,stale}", fg = "gray" },
+	# Special file
+	{ url = "*", is = "orphan", bg = "red" },
+	{ url = "*", is = "exec"  , fg = "green" },
+	# Dummy file
+	{ url = "*", is = "dummy", bg = "red" },
+	{ url = "*/", is = "dummy", bg = "red" },
+	# Fallback
+	{ url = "*/", fg = "blue" }
+]
+
+# : }}}
+
+
+# : Icons {{{
+
+[icon]
+globs = []
+dirs  = [
+	{ name = ".config", text = "", fg = "#ff9800" },
+	{ name = ".git", text = "", fg = "#00bcd4" },
+	{ name = ".github", text = "", fg = "#03a9f4" },
+	{ name = ".npm", text = "", fg = "#03a9f4" },
+	{ name = "Desktop", text = "", fg = "#00bcd4" },
+	{ name = "Development", text = "", fg = "#00bcd4" },
+	{ name = "Documents", text = "", fg = "#00bcd4" },
+	{ name = "Downloads", text = "", fg = "#00bcd4" },
+	{ name = "Library", text = "", fg = "#00bcd4" },
+	{ name = "Movies", text = "", fg = "#00bcd4" },
+	{ name = "Music", text = "", fg = "#00bcd4" },
+	{ name = "Pictures", text = "", fg = "#00bcd4" },
+	{ name = "Public", text = "", fg = "#00bcd4" },
+	{ name = "Videos", text = "", fg = "#00bcd4" },
+]
+files = [
+	{ name = ".babelrc", text = "", fg = "#cbcb41" },
+	{ name = ".bash_profile", text = "", fg = "#89e051" },
+	{ name = ".bashrc", text = "", fg = "#89e051" },
+	{ name = ".clang-format", text = "", fg = "#6d8086" },
+	{ name = ".clang-tidy", text = "", fg = "#6d8086" },
+	{ name = ".codespellrc", text = "󰓆", fg = "#35da60" },
+	{ name = ".condarc", text = "", fg = "#43b02a" },
+	{ name = ".dockerignore", text = "󰡨", fg = "#458ee6" },
+	{ name = ".ds_store", text = "", fg = "#41535b" },
+	{ name = ".editorconfig", text = "", fg = "#fff2f2" },
+	{ name = ".env", text = "", fg = "#faf743" },
+	{ name = ".eslintignore", text = "", fg = "#4b32c3" },
+	{ name = ".eslintrc", text = "", fg = "#4b32c3" },
+	{ name = ".git-blame-ignore-revs", text = "", fg = "#f54d27" },
+	{ name = ".gitattributes", text = "", fg = "#f54d27" },
+	{ name = ".gitconfig", text = "", fg = "#f54d27" },
+	{ name = ".gitignore", text = "", fg = "#f54d27" },
+	{ name = ".gitlab-ci.yml", text = "", fg = "#e24329" },
+	{ name = ".gitmodules", text = "", fg = "#f54d27" },
+	{ name = ".gtkrc-2.0", text = "", fg = "#ffffff" },
+	{ name = ".gvimrc", text = "", fg = "#019833" },
+	{ name = ".justfile", text = "", fg = "#6d8086" },
+	{ name = ".luacheckrc", text = "", fg = "#00a2ff" },
+	{ name = ".luaurc", text = "", fg = "#00a2ff" },
+	{ name = ".mailmap", text = "󰊢", fg = "#f54d27" },
+	{ name = ".nanorc", text = "", fg = "#440077" },
+	{ name = ".npmignore", text = "", fg = "#e8274b" },
+	{ name = ".npmrc", text = "", fg = "#e8274b" },
+	{ name = ".nuxtrc", text = "󱄆", fg = "#00c58e" },
+	{ name = ".nvmrc", text = "", fg = "#5fa04e" },
+	{ name = ".pnpmfile.cjs", text = "", fg = "#f9ad02" },
+	{ name = ".pre-commit-config.yaml", text = "󰛢", fg = "#f8b424" },
+	{ name = ".prettierignore", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.cjs", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.js", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.json", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.json5", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.mjs", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.toml", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.yaml", text = "", fg = "#4285f4" },
+	{ name = ".prettierrc.yml", text = "", fg = "#4285f4" },
+	{ name = ".pylintrc", text = "", fg = "#6d8086" },
+	{ name = ".settings.json", text = "", fg = "#854cc7" },
+	{ name = ".SRCINFO", text = "󰣇", fg = "#0f94d2" },
+	{ name = ".vimrc", text = "", fg = "#019833" },
+	{ name = ".Xauthority", text = "", fg = "#e54d18" },
+	{ name = ".xinitrc", text = "", fg = "#e54d18" },
+	{ name = ".Xresources", text = "", fg = "#e54d18" },
+	{ name = ".xsession", text = "", fg = "#e54d18" },
+	{ name = ".zprofile", text = "", fg = "#89e051" },
+	{ name = ".zshenv", text = "", fg = "#89e051" },
+	{ name = ".zshrc", text = "", fg = "#89e051" },
+	{ name = "_gvimrc", text = "", fg = "#019833" },
+	{ name = "_vimrc", text = "", fg = "#019833" },
+	{ name = "AUTHORS", text = "", fg = "#a172ff" },
+	{ name = "AUTHORS.txt", text = "", fg = "#a172ff" },
+	{ name = "brewfile", text = "", fg = "#701516" },
+	{ name = "bspwmrc", text = "", fg = "#2f2f2f" },
+	{ name = "build", text = "", fg = "#89e051" },
+	{ name = "build.gradle", text = "", fg = "#005f87" },
+	{ name = "build.zig.zon", text = "", fg = "#f69a1b" },
+	{ name = "bun.lock", text = "", fg = "#eadcd1" },
+	{ name = "bun.lockb", text = "", fg = "#eadcd1" },
+	{ name = "cantorrc", text = "", fg = "#1c99f3" },
+	{ name = "checkhealth", text = "󰓙", fg = "#75b4fb" },
+	{ name = "cmakelists.txt", text = "", fg = "#dce3eb" },
+	{ name = "code_of_conduct", text = "", fg = "#e41662" },
+	{ name = "code_of_conduct.md", text = "", fg = "#e41662" },
+	{ name = "commit_editmsg", text = "", fg = "#f54d27" },
+	{ name = "commitlint.config.js", text = "󰜘", fg = "#2b9689" },
+	{ name = "commitlint.config.ts", text = "󰜘", fg = "#2b9689" },
+	{ name = "compose.yaml", text = "󰡨", fg = "#458ee6" },
+	{ name = "compose.yml", text = "󰡨", fg = "#458ee6" },
+	{ name = "config", text = "", fg = "#6d8086" },
+	{ name = "containerfile", text = "󰡨", fg = "#458ee6" },
+	{ name = "copying", text = "", fg = "#cbcb41" },
+	{ name = "copying.lesser", text = "", fg = "#cbcb41" },
+	{ name = "Directory.Build.props", text = "", fg = "#00a2ff" },
+	{ name = "Directory.Build.targets", text = "", fg = "#00a2ff" },
+	{ name = "Directory.Packages.props", text = "", fg = "#00a2ff" },
+	{ name = "docker-compose.yaml", text = "󰡨", fg = "#458ee6" },
+	{ name = "docker-compose.yml", text = "󰡨", fg = "#458ee6" },
+	{ name = "dockerfile", text = "󰡨", fg = "#458ee6" },
+	{ name = "eslint.config.cjs", text = "", fg = "#4b32c3" },
+	{ name = "eslint.config.js", text = "", fg = "#4b32c3" },
+	{ name = "eslint.config.mjs", text = "", fg = "#4b32c3" },
+	{ name = "eslint.config.ts", text = "", fg = "#4b32c3" },
+	{ name = "ext_typoscript_setup.txt", text = "", fg = "#ff8700" },
+	{ name = "favicon.ico", text = "", fg = "#cbcb41" },
+	{ name = "fp-info-cache", text = "", fg = "#ffffff" },
+	{ name = "fp-lib-table", text = "", fg = "#ffffff" },
+	{ name = "FreeCAD.conf", text = "", fg = "#cb333b" },
+	{ name = "Gemfile", text = "", fg = "#701516" },
+	{ name = "gnumakefile", text = "", fg = "#6d8086" },
+	{ name = "go.mod", text = "", fg = "#00add8" },
+	{ name = "go.sum", text = "", fg = "#00add8" },
+	{ name = "go.work", text = "", fg = "#00add8" },
+	{ name = "gradle-wrapper.properties", text = "", fg = "#005f87" },
+	{ name = "gradle.properties", text = "", fg = "#005f87" },
+	{ name = "gradlew", text = "", fg = "#005f87" },
+	{ name = "groovy", text = "", fg = "#4a687c" },
+	{ name = "gruntfile.babel.js", text = "", fg = "#e37933" },
+	{ name = "gruntfile.coffee", text = "", fg = "#e37933" },
+	{ name = "gruntfile.js", text = "", fg = "#e37933" },
+	{ name = "gruntfile.ts", text = "", fg = "#e37933" },
+	{ name = "gtkrc", text = "", fg = "#ffffff" },
+	{ name = "gulpfile.babel.js", text = "", fg = "#cc3e44" },
+	{ name = "gulpfile.coffee", text = "", fg = "#cc3e44" },
+	{ name = "gulpfile.js", text = "", fg = "#cc3e44" },
+	{ name = "gulpfile.ts", text = "", fg = "#cc3e44" },
+	{ name = "hypridle.conf", text = "", fg = "#00aaae" },
+	{ name = "hyprland.conf", text = "", fg = "#00aaae" },
+	{ name = "hyprlandd.conf", text = "", fg = "#00aaae" },
+	{ name = "hyprlock.conf", text = "", fg = "#00aaae" },
+	{ name = "hyprpaper.conf", text = "", fg = "#00aaae" },
+	{ name = "hyprsunset.conf", text = "", fg = "#00aaae" },
+	{ name = "i18n.config.js", text = "󰗊", fg = "#7986cb" },
+	{ name = "i18n.config.ts", text = "󰗊", fg = "#7986cb" },
+	{ name = "i3blocks.conf", text = "", fg = "#e8ebee" },
+	{ name = "i3status.conf", text = "", fg = "#e8ebee" },
+	{ name = "index.theme", text = "", fg = "#2db96f" },
+	{ name = "ionic.config.json", text = "", fg = "#4f8ff7" },
+	{ name = "Jenkinsfile", text = "", fg = "#d33833" },
+	{ name = "justfile", text = "", fg = "#6d8086" },
+	{ name = "kalgebrarc", text = "", fg = "#1c99f3" },
+	{ name = "kdeglobals", text = "", fg = "#1c99f3" },
+	{ name = "kdenlive-layoutsrc", text = "", fg = "#83b8f2" },
+	{ name = "kdenliverc", text = "", fg = "#83b8f2" },
+	{ name = "kritadisplayrc", text = "", fg = "#f245fb" },
+	{ name = "kritarc", text = "", fg = "#f245fb" },
+	{ name = "license", text = "", fg = "#d0bf41" },
+	{ name = "license.md", text = "", fg = "#d0bf41" },
+	{ name = "lxde-rc.xml", text = "", fg = "#909090" },
+	{ name = "lxqt.conf", text = "", fg = "#0192d3" },
+	{ name = "makefile", text = "", fg = "#6d8086" },
+	{ name = "mix.lock", text = "", fg = "#a074c4" },
+	{ name = "mpv.conf", text = "", fg = "#3b1342" },
+	{ name = "next.config.cjs", text = "", fg = "#ffffff" },
+	{ name = "next.config.js", text = "", fg = "#ffffff" },
+	{ name = "next.config.ts", text = "", fg = "#ffffff" },
+	{ name = "node_modules", text = "", fg = "#e8274b" },
+	{ name = "nuxt.config.cjs", text = "󱄆", fg = "#00c58e" },
+	{ name = "nuxt.config.js", text = "󱄆", fg = "#00c58e" },
+	{ name = "nuxt.config.mjs", text = "󱄆", fg = "#00c58e" },
+	{ name = "nuxt.config.ts", text = "󱄆", fg = "#00c58e" },
+	{ name = "package-lock.json", text = "", fg = "#7a0d21" },
+	{ name = "package.json", text = "", fg = "#e8274b" },
+	{ name = "PKGBUILD", text = "", fg = "#0f94d2" },
+	{ name = "platformio.ini", text = "", fg = "#f6822b" },
+	{ name = "playwright.config.cjs", text = "", fg = "#2fad33" },
+	{ name = "playwright.config.cts", text = "", fg = "#2fad33" },
+	{ name = "playwright.config.js", text = "", fg = "#2fad33" },
+	{ name = "playwright.config.mjs", text = "", fg = "#2fad33" },
+	{ name = "playwright.config.mts", text = "", fg = "#2fad33" },
+	{ name = "playwright.config.ts", text = "", fg = "#2fad33" },
+	{ name = "pnpm-lock.yaml", text = "", fg = "#f9ad02" },
+	{ name = "pnpm-workspace.yaml", text = "", fg = "#f9ad02" },
+	{ name = "pom.xml", text = "", fg = "#7a0d21" },
+	{ name = "prettier.config.cjs", text = "", fg = "#4285f4" },
+	{ name = "prettier.config.js", text = "", fg = "#4285f4" },
+	{ name = "prettier.config.mjs", text = "", fg = "#4285f4" },
+	{ name = "prettier.config.ts", text = "", fg = "#4285f4" },
+	{ name = "prisma.config.mts", text = "", fg = "#5a67d8" },
+	{ name = "prisma.config.ts", text = "", fg = "#5a67d8" },
+	{ name = "procfile", text = "", fg = "#a074c4" },
+	{ name = "PrusaSlicer.ini", text = "", fg = "#ec6b23" },
+	{ name = "PrusaSlicerGcodeViewer.ini", text = "", fg = "#ec6b23" },
+	{ name = "py.typed", text = "", fg = "#ffbc03" },
+	{ name = "QtProject.conf", text = "", fg = "#40cd52" },
+	{ name = "rakefile", text = "", fg = "#701516" },
+	{ name = "readme", text = "󰂺", fg = "#ededed" },
+	{ name = "readme.md", text = "󰂺", fg = "#ededed" },
+	{ name = "rmd", text = "", fg = "#519aba" },
+	{ name = "robots.txt", text = "󰚩", fg = "#5d7096" },
+	{ name = "security", text = "󰒃", fg = "#bec4c9" },
+	{ name = "security.md", text = "󰒃", fg = "#bec4c9" },
+	{ name = "settings.gradle", text = "", fg = "#005f87" },
+	{ name = "svelte.config.js", text = "", fg = "#ff3e00" },
+	{ name = "sxhkdrc", text = "", fg = "#2f2f2f" },
+	{ name = "sym-lib-table", text = "", fg = "#ffffff" },
+	{ name = "tailwind.config.js", text = "󱏿", fg = "#20c2e3" },
+	{ name = "tailwind.config.mjs", text = "󱏿", fg = "#20c2e3" },
+	{ name = "tailwind.config.ts", text = "󱏿", fg = "#20c2e3" },
+	{ name = "tmux.conf", text = "", fg = "#14ba19" },
+	{ name = "tmux.conf.local", text = "", fg = "#14ba19" },
+	{ name = "tsconfig.json", text = "", fg = "#519aba" },
+	{ name = "unlicense", text = "", fg = "#d0bf41" },
+	{ name = "vagrantfile", text = "", fg = "#1563ff" },
+	{ name = "vercel.json", text = "", fg = "#ffffff" },
+	{ name = "vite.config.cjs", text = "", fg = "#ffa800" },
+	{ name = "vite.config.cts", text = "", fg = "#ffa800" },
+	{ name = "vite.config.js", text = "", fg = "#ffa800" },
+	{ name = "vite.config.mjs", text = "", fg = "#ffa800" },
+	{ name = "vite.config.mts", text = "", fg = "#ffa800" },
+	{ name = "vite.config.ts", text = "", fg = "#ffa800" },
+	{ name = "vitest.config.cjs", text = "", fg = "#739b1b" },
+	{ name = "vitest.config.cts", text = "", fg = "#739b1b" },
+	{ name = "vitest.config.js", text = "", fg = "#739b1b" },
+	{ name = "vitest.config.mjs", text = "", fg = "#739b1b" },
+	{ name = "vitest.config.mts", text = "", fg = "#739b1b" },
+	{ name = "vitest.config.ts", text = "", fg = "#739b1b" },
+	{ name = "vlcrc", text = "󰕼", fg = "#ee7a00" },
+	{ name = "webpack", text = "󰜫", fg = "#519aba" },
+	{ name = "weston.ini", text = "", fg = "#ffbb01" },
+	{ name = "workspace", text = "", fg = "#89e051" },
+	{ name = "wrangler.jsonc", text = "", fg = "#f48120" },
+	{ name = "wrangler.toml", text = "", fg = "#f48120" },
+	{ name = "xdph.conf", text = "", fg = "#00aaae" },
+	{ name = "xmobarrc", text = "", fg = "#fd4d5d" },
+	{ name = "xmobarrc.hs", text = "", fg = "#fd4d5d" },
+	{ name = "xmonad.hs", text = "", fg = "#fd4d5d" },
+	{ name = "xorg.conf", text = "", fg = "#e54d18" },
+	{ name = "xsettingsd.conf", text = "", fg = "#e54d18" },
+]
+exts = [
+	{ name = "3gp", text = "", fg = "#fd971f" },
+	{ name = "3mf", text = "󰆧", fg = "#888888" },
+	{ name = "7z", text = "", fg = "#eca517" },
+	{ name = "a", text = "", fg = "#dcddd6" },
+	{ name = "aac", text = "", fg = "#00afff" },
+	{ name = "ada", text = "", fg = "#599eff" },
+	{ name = "adb", text = "", fg = "#599eff" },
+	{ name = "ads", text = "", fg = "#a074c4" },
+	{ name = "ai", text = "", fg = "#cbcb41" },
+	{ name = "aif", text = "", fg = "#00afff" },
+	{ name = "aiff", text = "", fg = "#00afff" },
+	{ name = "android", text = "", fg = "#34a853" },
+	{ name = "ape", text = "", fg = "#00afff" },
+	{ name = "apk", text = "", fg = "#34a853" },
+	{ name = "apl", text = "", fg = "#24a148" },
+	{ name = "app", text = "", fg = "#9f0500" },
+	{ name = "applescript", text = "", fg = "#6d8085" },
+	{ name = "asc", text = "󰦝", fg = "#576d7f" },
+	{ name = "asm", text = "", fg = "#0091bd" },
+	{ name = "ass", text = "󰨖", fg = "#ffb713" },
+	{ name = "astro", text = "", fg = "#e23f67" },
+	{ name = "avif", text = "", fg = "#a074c4" },
+	{ name = "awk", text = "", fg = "#4d5a5e" },
+	{ name = "azcli", text = "", fg = "#0078d4" },
+	{ name = "bak", text = "󰁯", fg = "#6d8086" },
+	{ name = "bash", text = "", fg = "#89e051" },
+	{ name = "bat", text = "", fg = "#c1f12e" },
+	{ name = "bazel", text = "", fg = "#89e051" },
+	{ name = "bib", text = "󱉟", fg = "#cbcb41" },
+	{ name = "bicep", text = "", fg = "#519aba" },
+	{ name = "bicepparam", text = "", fg = "#9f74b3" },
+	{ name = "bin", text = "", fg = "#9f0500" },
+	{ name = "blade.php", text = "", fg = "#f05340" },
+	{ name = "blend", text = "󰂫", fg = "#ea7600" },
+	{ name = "blp", text = "󰺾", fg = "#5796e2" },
+	{ name = "bmp", text = "", fg = "#a074c4" },
+	{ name = "bqn", text = "", fg = "#24a148" },
+	{ name = "brep", text = "󰻫", fg = "#839463" },
+	{ name = "bz", text = "", fg = "#eca517" },
+	{ name = "bz2", text = "", fg = "#eca517" },
+	{ name = "bz3", text = "", fg = "#eca517" },
+	{ name = "bzl", text = "", fg = "#89e051" },
+	{ name = "c", text = "", fg = "#599eff" },
+	{ name = "c++", text = "", fg = "#f34b7d" },
+	{ name = "cache", text = "", fg = "#ffffff" },
+	{ name = "cast", text = "", fg = "#fd971f" },
+	{ name = "cbl", text = "", fg = "#005ca5" },
+	{ name = "cc", text = "", fg = "#f34b7d" },
+	{ name = "ccm", text = "", fg = "#f34b7d" },
+	{ name = "cfc", text = "", fg = "#01a4ba" },
+	{ name = "cfg", text = "", fg = "#6d8086" },
+	{ name = "cfm", text = "", fg = "#01a4ba" },
+	{ name = "cjs", text = "", fg = "#cbcb41" },
+	{ name = "clj", text = "", fg = "#8dc149" },
+	{ name = "cljc", text = "", fg = "#8dc149" },
+	{ name = "cljd", text = "", fg = "#519aba" },
+	{ name = "cljs", text = "", fg = "#519aba" },
+	{ name = "cmake", text = "", fg = "#dce3eb" },
+	{ name = "cob", text = "", fg = "#005ca5" },
+	{ name = "cobol", text = "", fg = "#005ca5" },
+	{ name = "coffee", text = "", fg = "#cbcb41" },
+	{ name = "conda", text = "", fg = "#43b02a" },
+	{ name = "conf", text = "", fg = "#6d8086" },
+	{ name = "config.ru", text = "", fg = "#701516" },
+	{ name = "cow", text = "󰆚", fg = "#965824" },
+	{ name = "cp", text = "", fg = "#519aba" },
+	{ name = "cpp", text = "", fg = "#519aba" },
+	{ name = "cppm", text = "", fg = "#519aba" },
+	{ name = "cpy", text = "", fg = "#005ca5" },
+	{ name = "cr", text = "", fg = "#c8c8c8" },
+	{ name = "crdownload", text = "", fg = "#44cda8" },
+	{ name = "cs", text = "󰌛", fg = "#596706" },
+	{ name = "csh", text = "", fg = "#4d5a5e" },
+	{ name = "cshtml", text = "󱦗", fg = "#512bd4" },
+	{ name = "cson", text = "", fg = "#cbcb41" },
+	{ name = "csproj", text = "󰪮", fg = "#512bd4" },
+	{ name = "css", text = "", fg = "#663399" },
+	{ name = "csv", text = "", fg = "#89e051" },
+	{ name = "cts", text = "", fg = "#519aba" },
+	{ name = "cu", text = "", fg = "#89e051" },
+	{ name = "cue", text = "󰲹", fg = "#ed95ae" },
+	{ name = "cuh", text = "", fg = "#a074c4" },
+	{ name = "cxx", text = "", fg = "#519aba" },
+	{ name = "cxxm", text = "", fg = "#519aba" },
+	{ name = "d", text = "", fg = "#b03931" },
+	{ name = "d.ts", text = "", fg = "#d59855" },
+	{ name = "dart", text = "", fg = "#03589c" },
+	{ name = "db", text = "", fg = "#dad8d8" },
+	{ name = "dconf", text = "", fg = "#ffffff" },
+	{ name = "desktop", text = "", fg = "#563d7c" },
+	{ name = "diff", text = "", fg = "#41535b" },
+	{ name = "dll", text = "", fg = "#4d2c0b" },
+	{ name = "doc", text = "󰈬", fg = "#185abd" },
+	{ name = "Dockerfile", text = "󰡨", fg = "#458ee6" },
+	{ name = "dockerignore", text = "󰡨", fg = "#458ee6" },
+	{ name = "docx", text = "󰈬", fg = "#185abd" },
+	{ name = "dot", text = "󱁉", fg = "#30638e" },
+	{ name = "download", text = "", fg = "#44cda8" },
+	{ name = "drl", text = "", fg = "#ffafaf" },
+	{ name = "dropbox", text = "", fg = "#0061fe" },
+	{ name = "dump", text = "", fg = "#dad8d8" },
+	{ name = "dwg", text = "󰻫", fg = "#839463" },
+	{ name = "dxf", text = "󰻫", fg = "#839463" },
+	{ name = "ebook", text = "", fg = "#eab16d" },
+	{ name = "ebuild", text = "", fg = "#4c416e" },
+	{ name = "edn", text = "", fg = "#519aba" },
+	{ name = "eex", text = "", fg = "#a074c4" },
+	{ name = "ejs", text = "", fg = "#cbcb41" },
+	{ name = "el", text = "", fg = "#8172be" },
+	{ name = "elc", text = "", fg = "#8172be" },
+	{ name = "elf", text = "", fg = "#9f0500" },
+	{ name = "elm", text = "", fg = "#519aba" },
+	{ name = "eln", text = "", fg = "#8172be" },
+	{ name = "env", text = "", fg = "#faf743" },
+	{ name = "eot", text = "", fg = "#ececec" },
+	{ name = "epp", text = "", fg = "#ffa61a" },
+	{ name = "epub", text = "", fg = "#eab16d" },
+	{ name = "erb", text = "", fg = "#701516" },
+	{ name = "erl", text = "", fg = "#b83998" },
+	{ name = "ex", text = "", fg = "#a074c4" },
+	{ name = "exe", text = "", fg = "#9f0500" },
+	{ name = "exs", text = "", fg = "#a074c4" },
+	{ name = "f#", text = "", fg = "#519aba" },
+	{ name = "f3d", text = "󰻫", fg = "#839463" },
+	{ name = "f90", text = "󱈚", fg = "#734f96" },
+	{ name = "fbx", text = "󰆧", fg = "#888888" },
+	{ name = "fcbak", text = "", fg = "#cb333b" },
+	{ name = "fcmacro", text = "", fg = "#cb333b" },
+	{ name = "fcmat", text = "", fg = "#cb333b" },
+	{ name = "fcparam", text = "", fg = "#cb333b" },
+	{ name = "fcscript", text = "", fg = "#cb333b" },
+	{ name = "fcstd", text = "", fg = "#cb333b" },
+	{ name = "fcstd1", text = "", fg = "#cb333b" },
+	{ name = "fctb", text = "", fg = "#cb333b" },
+	{ name = "fctl", text = "", fg = "#cb333b" },
+	{ name = "fdmdownload", text = "", fg = "#44cda8" },
+	{ name = "feature", text = "", fg = "#00a818" },
+	{ name = "fish", text = "", fg = "#4d5a5e" },
+	{ name = "flac", text = "", fg = "#0075aa" },
+	{ name = "flc", text = "", fg = "#ececec" },
+	{ name = "flf", text = "", fg = "#ececec" },
+	{ name = "fnl", text = "", fg = "#fff3d7" },
+	{ name = "fodg", text = "", fg = "#fffb57" },
+	{ name = "fodp", text = "", fg = "#fe9c45" },
+	{ name = "fods", text = "", fg = "#78fc4e" },
+	{ name = "fodt", text = "", fg = "#2dcbfd" },
+	{ name = "frag", text = "", fg = "#5586a6" },
+	{ name = "fs", text = "", fg = "#519aba" },
+	{ name = "fsi", text = "", fg = "#519aba" },
+	{ name = "fsscript", text = "", fg = "#519aba" },
+	{ name = "fsx", text = "", fg = "#519aba" },
+	{ name = "gcode", text = "󰐫", fg = "#1471ad" },
+	{ name = "gd", text = "", fg = "#6d8086" },
+	{ name = "gemspec", text = "", fg = "#701516" },
+	{ name = "geom", text = "", fg = "#5586a6" },
+	{ name = "gif", text = "", fg = "#a074c4" },
+	{ name = "git", text = "", fg = "#f14c28" },
+	{ name = "glb", text = "", fg = "#ffb13b" },
+	{ name = "gleam", text = "", fg = "#ffaff3" },
+	{ name = "glsl", text = "", fg = "#5586a6" },
+	{ name = "gnumakefile", text = "", fg = "#6d8086" },
+	{ name = "go", text = "", fg = "#00add8" },
+	{ name = "godot", text = "", fg = "#6d8086" },
+	{ name = "gpr", text = "", fg = "#6d8086" },
+	{ name = "gql", text = "", fg = "#e535ab" },
+	{ name = "gradle", text = "", fg = "#005f87" },
+	{ name = "graphql", text = "", fg = "#e535ab" },
+	{ name = "gresource", text = "", fg = "#ffffff" },
+	{ name = "gv", text = "󱁉", fg = "#30638e" },
+	{ name = "gz", text = "", fg = "#eca517" },
+	{ name = "h", text = "", fg = "#a074c4" },
+	{ name = "haml", text = "", fg = "#eaeae1" },
+	{ name = "hbs", text = "", fg = "#f0772b" },
+	{ name = "heex", text = "", fg = "#a074c4" },
+	{ name = "hex", text = "", fg = "#2e63ff" },
+	{ name = "hh", text = "", fg = "#a074c4" },
+	{ name = "hpp", text = "", fg = "#a074c4" },
+	{ name = "hrl", text = "", fg = "#b83998" },
+	{ name = "hs", text = "", fg = "#a074c4" },
+	{ name = "htm", text = "", fg = "#e34c26" },
+	{ name = "html", text = "", fg = "#e44d26" },
+	{ name = "http", text = "", fg = "#008ec7" },
+	{ name = "huff", text = "󰡘", fg = "#4242c7" },
+	{ name = "hurl", text = "", fg = "#ff0288" },
+	{ name = "hx", text = "", fg = "#ea8220" },
+	{ name = "hxx", text = "", fg = "#a074c4" },
+	{ name = "ical", text = "", fg = "#2b2e83" },
+	{ name = "icalendar", text = "", fg = "#2b2e83" },
+	{ name = "ico", text = "", fg = "#cbcb41" },
+	{ name = "ics", text = "", fg = "#2b2e83" },
+	{ name = "ifb", text = "", fg = "#2b2e83" },
+	{ name = "ifc", text = "󰻫", fg = "#839463" },
+	{ name = "ige", text = "󰻫", fg = "#839463" },
+	{ name = "iges", text = "󰻫", fg = "#839463" },
+	{ name = "igs", text = "󰻫", fg = "#839463" },
+	{ name = "image", text = "", fg = "#d0bec8" },
+	{ name = "img", text = "", fg = "#d0bec8" },
+	{ name = "import", text = "", fg = "#ececec" },
+	{ name = "info", text = "", fg = "#ffffcd" },
+	{ name = "ini", text = "", fg = "#6d8086" },
+	{ name = "ino", text = "", fg = "#56b6c2" },
+	{ name = "ipynb", text = "", fg = "#f57d01" },
+	{ name = "iso", text = "", fg = "#d0bec8" },
+	{ name = "ixx", text = "", fg = "#519aba" },
+	{ name = "jar", text = "", fg = "#ffaf67" },
+	{ name = "java", text = "", fg = "#cc3e44" },
+	{ name = "jl", text = "", fg = "#a270ba" },
+	{ name = "jpeg", text = "", fg = "#a074c4" },
+	{ name = "jpg", text = "", fg = "#a074c4" },
+	{ name = "js", text = "", fg = "#cbcb41" },
+	{ name = "json", text = "", fg = "#cbcb41" },
+	{ name = "json5", text = "", fg = "#cbcb41" },
+	{ name = "jsonc", text = "", fg = "#cbcb41" },
+	{ name = "jsx", text = "", fg = "#20c2e3" },
+	{ name = "jwmrc", text = "", fg = "#0078cd" },
+	{ name = "jxl", text = "", fg = "#a074c4" },
+	{ name = "kbx", text = "󰯄", fg = "#737672" },
+	{ name = "kdb", text = "", fg = "#529b34" },
+	{ name = "kdbx", text = "", fg = "#529b34" },
+	{ name = "kdenlive", text = "", fg = "#83b8f2" },
+	{ name = "kdenlivetitle", text = "", fg = "#83b8f2" },
+	{ name = "kicad_dru", text = "", fg = "#ffffff" },
+	{ name = "kicad_mod", text = "", fg = "#ffffff" },
+	{ name = "kicad_pcb", text = "", fg = "#ffffff" },
+	{ name = "kicad_prl", text = "", fg = "#ffffff" },
+	{ name = "kicad_pro", text = "", fg = "#ffffff" },
+	{ name = "kicad_sch", text = "", fg = "#ffffff" },
+	{ name = "kicad_sym", text = "", fg = "#ffffff" },
+	{ name = "kicad_wks", text = "", fg = "#ffffff" },
+	{ name = "ko", text = "", fg = "#dcddd6" },
+	{ name = "kpp", text = "", fg = "#f245fb" },
+	{ name = "kra", text = "", fg = "#f245fb" },
+	{ name = "krz", text = "", fg = "#f245fb" },
+	{ name = "ksh", text = "", fg = "#4d5a5e" },
+	{ name = "kt", text = "", fg = "#7f52ff" },
+	{ name = "kts", text = "", fg = "#7f52ff" },
+	{ name = "lck", text = "", fg = "#bbbbbb" },
+	{ name = "leex", text = "", fg = "#a074c4" },
+	{ name = "less", text = "", fg = "#563d7c" },
+	{ name = "lff", text = "", fg = "#ececec" },
+	{ name = "lhs", text = "", fg = "#a074c4" },
+	{ name = "lib", text = "", fg = "#4d2c0b" },
+	{ name = "license", text = "", fg = "#cbcb41" },
+	{ name = "liquid", text = "", fg = "#95bf47" },
+	{ name = "lock", text = "", fg = "#bbbbbb" },
+	{ name = "log", text = "󰌱", fg = "#dddddd" },
+	{ name = "lrc", text = "󰨖", fg = "#ffb713" },
+	{ name = "lua", text = "", fg = "#51a0cf" },
+	{ name = "luac", text = "", fg = "#51a0cf" },
+	{ name = "luau", text = "", fg = "#00a2ff" },
+	{ name = "m", text = "", fg = "#599eff" },
+	{ name = "m3u", text = "󰲹", fg = "#ed95ae" },
+	{ name = "m3u8", text = "󰲹", fg = "#ed95ae" },
+	{ name = "m4a", text = "", fg = "#00afff" },
+	{ name = "m4v", text = "", fg = "#fd971f" },
+	{ name = "magnet", text = "", fg = "#a51b16" },
+	{ name = "makefile", text = "", fg = "#6d8086" },
+	{ name = "markdown", text = "", fg = "#dddddd" },
+	{ name = "material", text = "", fg = "#b83998" },
+	{ name = "md", text = "", fg = "#dddddd" },
+	{ name = "md5", text = "󰕥", fg = "#8c86af" },
+	{ name = "mdx", text = "", fg = "#519aba" },
+	{ name = "mint", text = "󰌪", fg = "#87c095" },
+	{ name = "mjs", text = "", fg = "#f1e05a" },
+	{ name = "mk", text = "", fg = "#6d8086" },
+	{ name = "mkv", text = "", fg = "#fd971f" },
+	{ name = "ml", text = "", fg = "#e37933" },
+	{ name = "mli", text = "", fg = "#e37933" },
+	{ name = "mm", text = "", fg = "#519aba" },
+	{ name = "mo", text = "", fg = "#9772fb" },
+	{ name = "mobi", text = "", fg = "#eab16d" },
+	{ name = "mojo", text = "", fg = "#ff4c1f" },
+	{ name = "mov", text = "", fg = "#fd971f" },
+	{ name = "mp3", text = "", fg = "#00afff" },
+	{ name = "mp4", text = "", fg = "#fd971f" },
+	{ name = "mpp", text = "", fg = "#519aba" },
+	{ name = "msf", text = "", fg = "#137be1" },
+	{ name = "mts", text = "", fg = "#519aba" },
+	{ name = "mustache", text = "", fg = "#e37933" },
+	{ name = "nfo", text = "", fg = "#ffffcd" },
+	{ name = "nim", text = "", fg = "#f3d400" },
+	{ name = "nix", text = "", fg = "#7ebae4" },
+	{ name = "norg", text = "", fg = "#4878be" },
+	{ name = "nswag", text = "", fg = "#85ea2d" },
+	{ name = "nu", text = "", fg = "#3aa675" },
+	{ name = "o", text = "", fg = "#9f0500" },
+	{ name = "obj", text = "󰆧", fg = "#888888" },
+	{ name = "odf", text = "", fg = "#ff5a96" },
+	{ name = "odg", text = "", fg = "#fffb57" },
+	{ name = "odin", text = "󰟢", fg = "#3882d2" },
+	{ name = "odp", text = "", fg = "#fe9c45" },
+	{ name = "ods", text = "", fg = "#78fc4e" },
+	{ name = "odt", text = "", fg = "#2dcbfd" },
+	{ name = "oga", text = "", fg = "#0075aa" },
+	{ name = "ogg", text = "", fg = "#0075aa" },
+	{ name = "ogv", text = "", fg = "#fd971f" },
+	{ name = "ogx", text = "", fg = "#fd971f" },
+	{ name = "opus", text = "", fg = "#0075aa" },
+	{ name = "org", text = "", fg = "#77aa99" },
+	{ name = "otf", text = "", fg = "#ececec" },
+	{ name = "out", text = "", fg = "#9f0500" },
+	{ name = "part", text = "", fg = "#44cda8" },
+	{ name = "patch", text = "", fg = "#41535b" },
+	{ name = "pck", text = "", fg = "#6d8086" },
+	{ name = "pcm", text = "", fg = "#0075aa" },
+	{ name = "pdf", text = "", fg = "#b30b00" },
+	{ name = "php", text = "", fg = "#a074c4" },
+	{ name = "pl", text = "", fg = "#519aba" },
+	{ name = "pls", text = "󰲹", fg = "#ed95ae" },
+	{ name = "ply", text = "󰆧", fg = "#888888" },
+	{ name = "pm", text = "", fg = "#519aba" },
+	{ name = "png", text = "", fg = "#a074c4" },
+	{ name = "po", text = "", fg = "#2596be" },
+	{ name = "pot", text = "", fg = "#2596be" },
+	{ name = "pp", text = "", fg = "#ffa61a" },
+	{ name = "ppt", text = "󰈧", fg = "#cb4a32" },
+	{ name = "pptx", text = "󰈧", fg = "#cb4a32" },
+	{ name = "prisma", text = "", fg = "#5a67d8" },
+	{ name = "pro", text = "", fg = "#e4b854" },
+	{ name = "ps1", text = "󰨊", fg = "#4273ca" },
+	{ name = "psb", text = "", fg = "#519aba" },
+	{ name = "psd", text = "", fg = "#519aba" },
+	{ name = "psd1", text = "󰨊", fg = "#6975c4" },
+	{ name = "psm1", text = "󰨊", fg = "#6975c4" },
+	{ name = "pub", text = "󰷖", fg = "#e3c58e" },
+	{ name = "pxd", text = "", fg = "#5aa7e4" },
+	{ name = "pxi", text = "", fg = "#5aa7e4" },
+	{ name = "py", text = "", fg = "#ffbc03" },
+	{ name = "pyc", text = "", fg = "#ffe291" },
+	{ name = "pyd", text = "", fg = "#ffe291" },
+	{ name = "pyi", text = "", fg = "#ffbc03" },
+	{ name = "pyo", text = "", fg = "#ffe291" },
+	{ name = "pyw", text = "", fg = "#5aa7e4" },
+	{ name = "pyx", text = "", fg = "#5aa7e4" },
+	{ name = "qm", text = "", fg = "#2596be" },
+	{ name = "qml", text = "", fg = "#40cd52" },
+	{ name = "qrc", text = "", fg = "#40cd52" },
+	{ name = "qss", text = "", fg = "#40cd52" },
+	{ name = "query", text = "", fg = "#90a850" },
+	{ name = "R", text = "󰟔", fg = "#2266ba" },
+	{ name = "r", text = "󰟔", fg = "#2266ba" },
+	{ name = "rake", text = "", fg = "#701516" },
+	{ name = "rar", text = "", fg = "#eca517" },
+	{ name = "rasi", text = "", fg = "#cbcb41" },
+	{ name = "razor", text = "󱦘", fg = "#512bd4" },
+	{ name = "rb", text = "", fg = "#701516" },
+	{ name = "res", text = "", fg = "#cc3e44" },
+	{ name = "resi", text = "", fg = "#f55385" },
+	{ name = "rlib", text = "", fg = "#dea584" },
+	{ name = "rmd", text = "", fg = "#519aba" },
+	{ name = "rproj", text = "󰗆", fg = "#358a5b" },
+	{ name = "rs", text = "", fg = "#dea584" },
+	{ name = "rss", text = "", fg = "#fb9d3b" },
+	{ name = "s", text = "", fg = "#0071c5" },
+	{ name = "sass", text = "", fg = "#f55385" },
+	{ name = "sbt", text = "", fg = "#cc3e44" },
+	{ name = "sc", text = "", fg = "#cc3e44" },
+	{ name = "scad", text = "", fg = "#f9d72c" },
+	{ name = "scala", text = "", fg = "#cc3e44" },
+	{ name = "scm", text = "󰘧", fg = "#eeeeee" },
+	{ name = "scss", text = "", fg = "#f55385" },
+	{ name = "sh", text = "", fg = "#4d5a5e" },
+	{ name = "sha1", text = "󰕥", fg = "#8c86af" },
+	{ name = "sha224", text = "󰕥", fg = "#8c86af" },
+	{ name = "sha256", text = "󰕥", fg = "#8c86af" },
+	{ name = "sha384", text = "󰕥", fg = "#8c86af" },
+	{ name = "sha512", text = "󰕥", fg = "#8c86af" },
+	{ name = "sig", text = "󰘧", fg = "#e37933" },
+	{ name = "signature", text = "󰘧", fg = "#e37933" },
+	{ name = "skp", text = "󰻫", fg = "#839463" },
+	{ name = "sldasm", text = "󰻫", fg = "#839463" },
+	{ name = "sldprt", text = "󰻫", fg = "#839463" },
+	{ name = "slim", text = "", fg = "#e34c26" },
+	{ name = "sln", text = "", fg = "#854cc7" },
+	{ name = "slnx", text = "", fg = "#854cc7" },
+	{ name = "slvs", text = "󰻫", fg = "#839463" },
+	{ name = "sml", text = "󰘧", fg = "#e37933" },
+	{ name = "so", text = "", fg = "#dcddd6" },
+	{ name = "sol", text = "", fg = "#519aba" },
+	{ name = "spec.js", text = "", fg = "#cbcb41" },
+	{ name = "spec.jsx", text = "", fg = "#20c2e3" },
+	{ name = "spec.ts", text = "", fg = "#519aba" },
+	{ name = "spec.tsx", text = "", fg = "#1354bf" },
+	{ name = "spx", text = "", fg = "#0075aa" },
+	{ name = "sql", text = "", fg = "#dad8d8" },
+	{ name = "sqlite", text = "", fg = "#dad8d8" },
+	{ name = "sqlite3", text = "", fg = "#dad8d8" },
+	{ name = "srt", text = "󰨖", fg = "#ffb713" },
+	{ name = "ssa", text = "󰨖", fg = "#ffb713" },
+	{ name = "ste", text = "󰻫", fg = "#839463" },
+	{ name = "step", text = "󰻫", fg = "#839463" },
+	{ name = "stl", text = "󰆧", fg = "#888888" },
+	{ name = "stories.js", text = "", fg = "#ff4785" },
+	{ name = "stories.jsx", text = "", fg = "#ff4785" },
+	{ name = "stories.mjs", text = "", fg = "#ff4785" },
+	{ name = "stories.svelte", text = "", fg = "#ff4785" },
+	{ name = "stories.ts", text = "", fg = "#ff4785" },
+	{ name = "stories.tsx", text = "", fg = "#ff4785" },
+	{ name = "stories.vue", text = "", fg = "#ff4785" },
+	{ name = "stp", text = "󰻫", fg = "#839463" },
+	{ name = "strings", text = "", fg = "#2596be" },
+	{ name = "styl", text = "", fg = "#8dc149" },
+	{ name = "sub", text = "󰨖", fg = "#ffb713" },
+	{ name = "sublime", text = "", fg = "#e37933" },
+	{ name = "suo", text = "", fg = "#854cc7" },
+	{ name = "sv", text = "󰍛", fg = "#019833" },
+	{ name = "svelte", text = "", fg = "#ff3e00" },
+	{ name = "svg", text = "󰜡", fg = "#ffb13b" },
+	{ name = "svgz", text = "󰜡", fg = "#ffb13b" },
+	{ name = "svh", text = "󰍛", fg = "#019833" },
+	{ name = "swift", text = "", fg = "#e37933" },
+	{ name = "t", text = "", fg = "#519aba" },
+	{ name = "tbc", text = "󰛓", fg = "#1e5cb3" },
+	{ name = "tcl", text = "󰛓", fg = "#1e5cb3" },
+	{ name = "templ", text = "", fg = "#dbbd30" },
+	{ name = "terminal", text = "", fg = "#31b53e" },
+	{ name = "test.js", text = "", fg = "#cbcb41" },
+	{ name = "test.jsx", text = "", fg = "#20c2e3" },
+	{ name = "test.ts", text = "", fg = "#519aba" },
+	{ name = "test.tsx", text = "", fg = "#1354bf" },
+	{ name = "tex", text = "", fg = "#3d6117" },
+	{ name = "tf", text = "", fg = "#5f43e9" },
+	{ name = "tfvars", text = "", fg = "#5f43e9" },
+	{ name = "tgz", text = "", fg = "#eca517" },
+	{ name = "tmpl", text = "", fg = "#dbbd30" },
+	{ name = "tmux", text = "", fg = "#14ba19" },
+	{ name = "toml", text = "", fg = "#9c4221" },
+	{ name = "torrent", text = "", fg = "#44cda8" },
+	{ name = "tres", text = "", fg = "#6d8086" },
+	{ name = "ts", text = "", fg = "#519aba" },
+	{ name = "tscn", text = "", fg = "#6d8086" },
+	{ name = "tsconfig", text = "", fg = "#ff8700" },
+	{ name = "tsx", text = "", fg = "#1354bf" },
+	{ name = "ttf", text = "", fg = "#ececec" },
+	{ name = "twig", text = "", fg = "#8dc149" },
+	{ name = "txt", text = "󰈙", fg = "#89e051" },
+	{ name = "txz", text = "", fg = "#eca517" },
+	{ name = "typ", text = "", fg = "#0dbcc0" },
+	{ name = "typoscript", text = "", fg = "#ff8700" },
+	{ name = "ui", text = "", fg = "#015bf0" },
+	{ name = "v", text = "󰍛", fg = "#019833" },
+	{ name = "vala", text = "", fg = "#7b3db9" },
+	{ name = "vert", text = "", fg = "#5586a6" },
+	{ name = "vh", text = "󰍛", fg = "#019833" },
+	{ name = "vhd", text = "󰍛", fg = "#019833" },
+	{ name = "vhdl", text = "󰍛", fg = "#019833" },
+	{ name = "vi", text = "", fg = "#fec60a" },
+	{ name = "vim", text = "", fg = "#019833" },
+	{ name = "vsh", text = "", fg = "#5d87bf" },
+	{ name = "vsix", text = "", fg = "#854cc7" },
+	{ name = "vue", text = "", fg = "#8dc149" },
+	{ name = "wasm", text = "", fg = "#5c4cdb" },
+	{ name = "wav", text = "", fg = "#00afff" },
+	{ name = "webm", text = "", fg = "#fd971f" },
+	{ name = "webmanifest", text = "", fg = "#f1e05a" },
+	{ name = "webp", text = "", fg = "#a074c4" },
+	{ name = "webpack", text = "󰜫", fg = "#519aba" },
+	{ name = "wma", text = "", fg = "#00afff" },
+	{ name = "wmv", text = "", fg = "#fd971f" },
+	{ name = "woff", text = "", fg = "#ececec" },
+	{ name = "woff2", text = "", fg = "#ececec" },
+	{ name = "wrl", text = "󰆧", fg = "#888888" },
+	{ name = "wrz", text = "󰆧", fg = "#888888" },
+	{ name = "wv", text = "", fg = "#00afff" },
+	{ name = "wvc", text = "", fg = "#00afff" },
+	{ name = "x", text = "", fg = "#599eff" },
+	{ name = "xaml", text = "󰙳", fg = "#512bd4" },
+	{ name = "xcf", text = "", fg = "#635b46" },
+	{ name = "xcplayground", text = "", fg = "#e37933" },
+	{ name = "xcstrings", text = "", fg = "#2596be" },
+	{ name = "xls", text = "󰈛", fg = "#207245" },
+	{ name = "xlsx", text = "󰈛", fg = "#207245" },
+	{ name = "xm", text = "", fg = "#519aba" },
+	{ name = "xml", text = "󰗀", fg = "#e37933" },
+	{ name = "xpi", text = "", fg = "#ff1b01" },
+	{ name = "xslt", text = "󰗀", fg = "#33a9dc" },
+	{ name = "xul", text = "", fg = "#e37933" },
+	{ name = "xz", text = "", fg = "#eca517" },
+	{ name = "yaml", text = "", fg = "#6d8086" },
+	{ name = "yml", text = "", fg = "#6d8086" },
+	{ name = "zig", text = "", fg = "#f69a1b" },
+	{ name = "zip", text = "", fg = "#eca517" },
+	{ name = "zsh", text = "", fg = "#89e051" },
+	{ name = "zst", text = "", fg = "#eca517" },
+	{ name = "🔥", text = "", fg = "#ff4c1f" },
+]
+conds = [
+	# Special files
+	{ if = "orphan", text = "", fg = "#ffffff" },
+	{ if = "link", text = "", fg = "#9e9e9e" },
+	{ if = "block", text = "", fg = "#cddc39" },
+	{ if = "char", text = "", fg = "#cddc39" },
+	{ if = "fifo", text = "", fg = "#cddc39" },
+	{ if = "sock", text = "", fg = "#cddc39" },
+	{ if = "sticky", text = "", fg = "#cddc39" },
+	{ if = "dummy", text = "", fg = "#f44336" },
+
+	# Fallback
+	{ if = "dir & hovered", text = "", fg = "#03a9f4" },
+	{ if = "dir", text = "", fg = "#03a9f4" },
+	{ if = "exec", text = "", fg = "#8bc34a" },
+	{ if = "!dir", text = "", fg = "#ffffff" },
+]
+
+# : }}}

--- a/src/components/Default/theme-light.toml
+++ b/src/components/Default/theme-light.toml
@@ -1,0 +1,1006 @@
+# If the user's terminal is in dark mode, Yazi will load `theme-dark.toml` on startup; otherwise, `theme-light.toml`.
+# You can override any parts of them that are not related to the dark/light mode in your own `theme.toml`.
+
+# If you want to dynamically override their content based on dark/light mode, you can specify two different flavors
+# for dark and light modes under `[flavor]`, and do so in those flavors instead.
+
+#:schema https://yazi-rs.github.io/schemas/theme.json
+# vim:fileencoding=utf-8:foldmethod=marker
+
+# : Flavor {{{
+
+[flavor]
+dark  = ""
+light = ""
+
+# : }}}
+
+
+# : App {{{
+
+[app]
+overall = {}
+
+# : }}}
+
+
+# : Manager {{{
+
+[mgr]
+cwd = { fg = "cyan" }
+
+# Find
+find_keyword  = { fg = "yellow", bold = true, italic = true, underline = true }
+find_position = { fg = "magenta", bg = "reset", bold = true, italic = true }
+
+# Symlink
+symlink_target = { italic = true }
+
+# Marker
+marker_copied   = { fg = "lightgreen",  bg = "lightgreen" }
+marker_cut      = { fg = "lightred",    bg = "lightred" }
+marker_marked   = { fg = "lightcyan",   bg = "lightcyan" }
+marker_selected = { fg = "lightyellow", bg = "lightyellow" }
+marker_symbol   = "│"
+
+# Count
+count_copied   = { fg = "white", bg = "green" }
+count_cut      = { fg = "white", bg = "red" }
+count_selected = { fg = "white", bg = "yellow" }
+
+# Border
+border_symbol = "│"
+border_style  = { fg = "gray" }
+
+# Highlighting
+syntect_theme = ""
+
+# : }}}
+
+
+# : Tabs {{{
+
+[tabs]
+active   = { bg = "blue", bold = true }
+inactive = { fg = "blue", bg = "gray" }
+
+# Separator
+sep_inner = { open = "", close = "" }
+sep_outer = { open = "", close = "" }
+
+# : }}}
+
+
+# : Mode {{{
+
+[mode]
+normal_main = { bg = "blue", bold = true }
+normal_alt  = { fg = "blue", bg = "gray" }
+
+# Select mode
+select_main = { bg = "red", bold = true }
+select_alt  = { fg = "red", bg = "gray" }
+
+# Unset mode
+unset_main = { bg = "red", bold = true }
+unset_alt  = { fg = "red", bg = "gray" }
+
+# : }}}
+
+
+# : Indicator of hovered file {{{
+
+[indicator]
+parent  = { reversed = true }
+current = { reversed = true }
+preview = { underline = true }
+padding = { open = "", close = "" }
+
+# : }}}
+
+
+# : Status bar {{{
+
+[status]
+overall   = {}
+sep_left  = { open = "", close = "" }
+sep_right = { open = "", close = "" }
+
+# Permissions
+perm_sep   = { fg = "darkgray" }
+perm_type  = { fg = "green" }
+perm_read  = { fg = "yellow" }
+perm_write = { fg = "red" }
+perm_exec  = { fg = "cyan" }
+
+# Progress
+progress_label  = { bold = true }
+progress_normal = { fg = "green", bg = "gray" }
+progress_error  = { fg = "yellow", bg = "red" }
+
+# : }}}
+
+
+# : Which {{{
+
+[which]
+cols            = 3
+mask            = { bg = "black" }
+cand            = { fg = "lightcyan" }
+rest            = { fg = "darkgray" }
+desc            = { fg = "lightmagenta" }
+separator       = "  "
+separator_style = { fg = "darkgray" }
+
+# : }}}
+
+
+# : Confirmation {{{
+
+[confirm]
+border     = { fg = "blue" }
+title      = { fg = "blue" }
+body       = {}
+list       = {}
+btn_yes    = { reversed = true }
+btn_no     = {}
+btn_labels = [ "  [Y]es  ", "  (N)o  " ]
+
+# : }}}
+
+
+# : Spotter {{{
+
+[spot]
+border = { fg = "blue" }
+title  = { fg = "blue" }
+
+# Table
+tbl_col  = { fg = "blue" }
+tbl_cell = { fg = "yellow", reversed = true }
+
+# : }}}
+
+
+# : Notification {{{
+
+[notify]
+title_info  = { fg = "green" }
+title_warn  = { fg = "yellow" }
+title_error = { fg = "red" }
+
+# Icons
+icon_info  = ""
+icon_warn  = ""
+icon_error = ""
+
+# : }}}
+
+
+# : Picker {{{
+
+[pick]
+border   = { fg = "blue" }
+active   = { fg = "magenta", bold = true }
+inactive = {}
+
+# : }}}
+
+
+# : Input {{{
+
+[input]
+border   = { fg = "blue" }
+title    = {}
+value    = {}
+selected = { reversed = true }
+
+# : }}}
+
+
+# : Completion {{{
+
+[cmp]
+border   = { fg = "blue" }
+active   = { reversed = true }
+inactive = {}
+
+# Icons
+icon_file    = ""
+icon_folder  = ""
+icon_command = ""
+
+# : }}}
+
+
+# : Task manager {{{
+
+[tasks]
+border  = { fg = "blue" }
+title   = {}
+hovered = { fg = "magenta", bold = true }
+
+# : }}}
+
+
+# : Help menu {{{
+
+[help]
+on      = { fg = "cyan" }
+run     = { fg = "magenta" }
+desc    = {}
+hovered = { reversed = true, bold = true }
+footer  = { fg = "black", bg = "white" }
+
+# : }}}
+
+
+# : File-specific styles {{{
+
+[filetype]
+rules = [
+	# Image
+	{ mime = "image/*", fg = "yellow" },
+	# Media
+	{ mime = "{audio,video}/*", fg = "magenta" },
+	# Archive
+	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "red" },
+	# Document
+	{ mime = "application/{pdf,doc,rtf}", fg = "cyan" },
+	# Virtual file system
+	{ mime = "vfs/{absent,stale}", fg = "darkgray" },
+	# Special file
+	{ url = "*", is = "orphan", bg = "red" },
+	{ url = "*", is = "exec"  , fg = "green" },
+	# Dummy file
+	{ url = "*", is = "dummy", bg = "red" },
+	{ url = "*/", is = "dummy", bg = "red" },
+	# Fallback
+	{ url = "*/", fg = "blue" }
+]
+
+# : }}}
+
+
+# : Icons {{{
+
+[icon]
+globs = []
+dirs  = [
+	{ name = ".config", text = "", fg = "#ff9800" },
+	{ name = ".git", text = "", fg = "#009688" },
+	{ name = ".github", text = "", fg = "#03a9f4" },
+	{ name = ".npm", text = "", fg = "#03a9f4" },
+	{ name = "Desktop", text = "", fg = "#009688" },
+	{ name = "Development", text = "", fg = "#009688" },
+	{ name = "Documents", text = "", fg = "#009688" },
+	{ name = "Downloads", text = "", fg = "#009688" },
+	{ name = "Library", text = "", fg = "#009688" },
+	{ name = "Movies", text = "", fg = "#009688" },
+	{ name = "Music", text = "", fg = "#009688" },
+	{ name = "Pictures", text = "", fg = "#009688" },
+	{ name = "Public", text = "", fg = "#009688" },
+	{ name = "Videos", text = "", fg = "#009688" },
+]
+files = [
+	{ name = ".babelrc", text = "", fg = "#666620" },
+	{ name = ".bash_profile", text = "", fg = "#447028" },
+	{ name = ".bashrc", text = "", fg = "#447028" },
+	{ name = ".clang-format", text = "", fg = "#526064" },
+	{ name = ".clang-tidy", text = "", fg = "#526064" },
+	{ name = ".codespellrc", text = "󰓆", fg = "#239140" },
+	{ name = ".condarc", text = "", fg = "#2d751c" },
+	{ name = ".dockerignore", text = "󰡨", fg = "#2e5f99" },
+	{ name = ".ds_store", text = "", fg = "#41535b" },
+	{ name = ".editorconfig", text = "", fg = "#333030" },
+	{ name = ".env", text = "", fg = "#32310d" },
+	{ name = ".eslintignore", text = "", fg = "#4b32c3" },
+	{ name = ".eslintrc", text = "", fg = "#4b32c3" },
+	{ name = ".git-blame-ignore-revs", text = "", fg = "#b83a1d" },
+	{ name = ".gitattributes", text = "", fg = "#b83a1d" },
+	{ name = ".gitconfig", text = "", fg = "#b83a1d" },
+	{ name = ".gitignore", text = "", fg = "#b83a1d" },
+	{ name = ".gitlab-ci.yml", text = "", fg = "#aa321f" },
+	{ name = ".gitmodules", text = "", fg = "#b83a1d" },
+	{ name = ".gtkrc-2.0", text = "", fg = "#333333" },
+	{ name = ".gvimrc", text = "", fg = "#017226" },
+	{ name = ".justfile", text = "", fg = "#526064" },
+	{ name = ".luacheckrc", text = "", fg = "#007abf" },
+	{ name = ".luaurc", text = "", fg = "#007abf" },
+	{ name = ".mailmap", text = "󰊢", fg = "#b83a1d" },
+	{ name = ".nanorc", text = "", fg = "#440077" },
+	{ name = ".npmignore", text = "", fg = "#ae1d38" },
+	{ name = ".npmrc", text = "", fg = "#ae1d38" },
+	{ name = ".nuxtrc", text = "󱄆", fg = "#00835f" },
+	{ name = ".nvmrc", text = "", fg = "#3f6b34" },
+	{ name = ".pnpmfile.cjs", text = "", fg = "#7c5601" },
+	{ name = ".pre-commit-config.yaml", text = "󰛢", fg = "#7c5a12" },
+	{ name = ".prettierignore", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.cjs", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.js", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.json", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.json5", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.mjs", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.toml", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.yaml", text = "", fg = "#3264b7" },
+	{ name = ".prettierrc.yml", text = "", fg = "#3264b7" },
+	{ name = ".pylintrc", text = "", fg = "#526064" },
+	{ name = ".settings.json", text = "", fg = "#643995" },
+	{ name = ".SRCINFO", text = "󰣇", fg = "#0b6f9e" },
+	{ name = ".vimrc", text = "", fg = "#017226" },
+	{ name = ".Xauthority", text = "", fg = "#ac3a12" },
+	{ name = ".xinitrc", text = "", fg = "#ac3a12" },
+	{ name = ".Xresources", text = "", fg = "#ac3a12" },
+	{ name = ".xsession", text = "", fg = "#ac3a12" },
+	{ name = ".zprofile", text = "", fg = "#447028" },
+	{ name = ".zshenv", text = "", fg = "#447028" },
+	{ name = ".zshrc", text = "", fg = "#447028" },
+	{ name = "_gvimrc", text = "", fg = "#017226" },
+	{ name = "_vimrc", text = "", fg = "#017226" },
+	{ name = "AUTHORS", text = "", fg = "#6b4caa" },
+	{ name = "AUTHORS.txt", text = "", fg = "#6b4caa" },
+	{ name = "brewfile", text = "", fg = "#701516" },
+	{ name = "bspwmrc", text = "", fg = "#2f2f2f" },
+	{ name = "build", text = "", fg = "#447028" },
+	{ name = "build.gradle", text = "", fg = "#005f87" },
+	{ name = "build.zig.zon", text = "", fg = "#7b4d0e" },
+	{ name = "bun.lock", text = "", fg = "#4e4946" },
+	{ name = "bun.lockb", text = "", fg = "#4e4946" },
+	{ name = "cantorrc", text = "", fg = "#1573b6" },
+	{ name = "checkhealth", text = "󰓙", fg = "#3a5a7e" },
+	{ name = "cmakelists.txt", text = "", fg = "#2c2d2f" },
+	{ name = "code_of_conduct", text = "", fg = "#ab104a" },
+	{ name = "code_of_conduct.md", text = "", fg = "#ab104a" },
+	{ name = "commit_editmsg", text = "", fg = "#b83a1d" },
+	{ name = "commitlint.config.js", text = "󰜘", fg = "#207067" },
+	{ name = "commitlint.config.ts", text = "󰜘", fg = "#207067" },
+	{ name = "compose.yaml", text = "󰡨", fg = "#2e5f99" },
+	{ name = "compose.yml", text = "󰡨", fg = "#2e5f99" },
+	{ name = "config", text = "", fg = "#526064" },
+	{ name = "containerfile", text = "󰡨", fg = "#2e5f99" },
+	{ name = "copying", text = "", fg = "#666620" },
+	{ name = "copying.lesser", text = "", fg = "#666620" },
+	{ name = "Directory.Build.props", text = "", fg = "#007abf" },
+	{ name = "Directory.Build.targets", text = "", fg = "#007abf" },
+	{ name = "Directory.Packages.props", text = "", fg = "#007abf" },
+	{ name = "docker-compose.yaml", text = "󰡨", fg = "#2e5f99" },
+	{ name = "docker-compose.yml", text = "󰡨", fg = "#2e5f99" },
+	{ name = "dockerfile", text = "󰡨", fg = "#2e5f99" },
+	{ name = "eslint.config.cjs", text = "", fg = "#4b32c3" },
+	{ name = "eslint.config.js", text = "", fg = "#4b32c3" },
+	{ name = "eslint.config.mjs", text = "", fg = "#4b32c3" },
+	{ name = "eslint.config.ts", text = "", fg = "#4b32c3" },
+	{ name = "ext_typoscript_setup.txt", text = "", fg = "#aa5a00" },
+	{ name = "favicon.ico", text = "", fg = "#666620" },
+	{ name = "fp-info-cache", text = "", fg = "#333333" },
+	{ name = "fp-lib-table", text = "", fg = "#333333" },
+	{ name = "FreeCAD.conf", text = "", fg = "#98262c" },
+	{ name = "Gemfile", text = "", fg = "#701516" },
+	{ name = "gnumakefile", text = "", fg = "#526064" },
+	{ name = "go.mod", text = "", fg = "#0082a2" },
+	{ name = "go.sum", text = "", fg = "#0082a2" },
+	{ name = "go.work", text = "", fg = "#0082a2" },
+	{ name = "gradle-wrapper.properties", text = "", fg = "#005f87" },
+	{ name = "gradle.properties", text = "", fg = "#005f87" },
+	{ name = "gradlew", text = "", fg = "#005f87" },
+	{ name = "groovy", text = "", fg = "#384e5d" },
+	{ name = "gruntfile.babel.js", text = "", fg = "#975122" },
+	{ name = "gruntfile.coffee", text = "", fg = "#975122" },
+	{ name = "gruntfile.js", text = "", fg = "#975122" },
+	{ name = "gruntfile.ts", text = "", fg = "#975122" },
+	{ name = "gtkrc", text = "", fg = "#333333" },
+	{ name = "gulpfile.babel.js", text = "", fg = "#992e33" },
+	{ name = "gulpfile.coffee", text = "", fg = "#992e33" },
+	{ name = "gulpfile.js", text = "", fg = "#992e33" },
+	{ name = "gulpfile.ts", text = "", fg = "#992e33" },
+	{ name = "hypridle.conf", text = "", fg = "#008082" },
+	{ name = "hyprland.conf", text = "", fg = "#008082" },
+	{ name = "hyprlandd.conf", text = "", fg = "#008082" },
+	{ name = "hyprlock.conf", text = "", fg = "#008082" },
+	{ name = "hyprpaper.conf", text = "", fg = "#008082" },
+	{ name = "hyprsunset.conf", text = "", fg = "#008082" },
+	{ name = "i18n.config.js", text = "󰗊", fg = "#515987" },
+	{ name = "i18n.config.ts", text = "󰗊", fg = "#515987" },
+	{ name = "i3blocks.conf", text = "", fg = "#2e2f30" },
+	{ name = "i3status.conf", text = "", fg = "#2e2f30" },
+	{ name = "index.theme", text = "", fg = "#1e7b4a" },
+	{ name = "ionic.config.json", text = "", fg = "#355fa5" },
+	{ name = "Jenkinsfile", text = "", fg = "#9e2a26" },
+	{ name = "justfile", text = "", fg = "#526064" },
+	{ name = "kalgebrarc", text = "", fg = "#1573b6" },
+	{ name = "kdeglobals", text = "", fg = "#1573b6" },
+	{ name = "kdenlive-layoutsrc", text = "", fg = "#425c79" },
+	{ name = "kdenliverc", text = "", fg = "#425c79" },
+	{ name = "kritadisplayrc", text = "", fg = "#a12ea7" },
+	{ name = "kritarc", text = "", fg = "#a12ea7" },
+	{ name = "license", text = "", fg = "#686020" },
+	{ name = "license.md", text = "", fg = "#686020" },
+	{ name = "lxde-rc.xml", text = "", fg = "#606060" },
+	{ name = "lxqt.conf", text = "", fg = "#016e9e" },
+	{ name = "makefile", text = "", fg = "#526064" },
+	{ name = "mix.lock", text = "", fg = "#6b4d83" },
+	{ name = "mpv.conf", text = "", fg = "#3b1342" },
+	{ name = "next.config.cjs", text = "", fg = "#333333" },
+	{ name = "next.config.js", text = "", fg = "#333333" },
+	{ name = "next.config.ts", text = "", fg = "#333333" },
+	{ name = "node_modules", text = "", fg = "#ae1d38" },
+	{ name = "nuxt.config.cjs", text = "󱄆", fg = "#00835f" },
+	{ name = "nuxt.config.js", text = "󱄆", fg = "#00835f" },
+	{ name = "nuxt.config.mjs", text = "󱄆", fg = "#00835f" },
+	{ name = "nuxt.config.ts", text = "󱄆", fg = "#00835f" },
+	{ name = "package-lock.json", text = "", fg = "#7a0d21" },
+	{ name = "package.json", text = "", fg = "#ae1d38" },
+	{ name = "PKGBUILD", text = "", fg = "#0b6f9e" },
+	{ name = "platformio.ini", text = "", fg = "#a4571d" },
+	{ name = "playwright.config.cjs", text = "", fg = "#238226" },
+	{ name = "playwright.config.cts", text = "", fg = "#238226" },
+	{ name = "playwright.config.js", text = "", fg = "#238226" },
+	{ name = "playwright.config.mjs", text = "", fg = "#238226" },
+	{ name = "playwright.config.mts", text = "", fg = "#238226" },
+	{ name = "playwright.config.ts", text = "", fg = "#238226" },
+	{ name = "pnpm-lock.yaml", text = "", fg = "#7c5601" },
+	{ name = "pnpm-workspace.yaml", text = "", fg = "#7c5601" },
+	{ name = "pom.xml", text = "", fg = "#7a0d21" },
+	{ name = "prettier.config.cjs", text = "", fg = "#3264b7" },
+	{ name = "prettier.config.js", text = "", fg = "#3264b7" },
+	{ name = "prettier.config.mjs", text = "", fg = "#3264b7" },
+	{ name = "prettier.config.ts", text = "", fg = "#3264b7" },
+	{ name = "prisma.config.mts", text = "", fg = "#444da2" },
+	{ name = "prisma.config.ts", text = "", fg = "#444da2" },
+	{ name = "procfile", text = "", fg = "#6b4d83" },
+	{ name = "PrusaSlicer.ini", text = "", fg = "#9d4717" },
+	{ name = "PrusaSlicerGcodeViewer.ini", text = "", fg = "#9d4717" },
+	{ name = "py.typed", text = "", fg = "#805e02" },
+	{ name = "QtProject.conf", text = "", fg = "#2b8937" },
+	{ name = "rakefile", text = "", fg = "#701516" },
+	{ name = "readme", text = "󰂺", fg = "#2f2f2f" },
+	{ name = "readme.md", text = "󰂺", fg = "#2f2f2f" },
+	{ name = "rmd", text = "", fg = "#36677c" },
+	{ name = "robots.txt", text = "󰚩", fg = "#465470" },
+	{ name = "security", text = "󰒃", fg = "#3f4143" },
+	{ name = "security.md", text = "󰒃", fg = "#3f4143" },
+	{ name = "settings.gradle", text = "", fg = "#005f87" },
+	{ name = "svelte.config.js", text = "", fg = "#bf2e00" },
+	{ name = "sxhkdrc", text = "", fg = "#2f2f2f" },
+	{ name = "sym-lib-table", text = "", fg = "#333333" },
+	{ name = "tailwind.config.js", text = "󱏿", fg = "#158197" },
+	{ name = "tailwind.config.mjs", text = "󱏿", fg = "#158197" },
+	{ name = "tailwind.config.ts", text = "󱏿", fg = "#158197" },
+	{ name = "tmux.conf", text = "", fg = "#0f8c13" },
+	{ name = "tmux.conf.local", text = "", fg = "#0f8c13" },
+	{ name = "tsconfig.json", text = "", fg = "#36677c" },
+	{ name = "unlicense", text = "", fg = "#686020" },
+	{ name = "vagrantfile", text = "", fg = "#104abf" },
+	{ name = "vercel.json", text = "", fg = "#333333" },
+	{ name = "vite.config.cjs", text = "", fg = "#805400" },
+	{ name = "vite.config.cts", text = "", fg = "#805400" },
+	{ name = "vite.config.js", text = "", fg = "#805400" },
+	{ name = "vite.config.mjs", text = "", fg = "#805400" },
+	{ name = "vite.config.mts", text = "", fg = "#805400" },
+	{ name = "vite.config.ts", text = "", fg = "#805400" },
+	{ name = "vitest.config.cjs", text = "", fg = "#4d6712" },
+	{ name = "vitest.config.cts", text = "", fg = "#4d6712" },
+	{ name = "vitest.config.js", text = "", fg = "#4d6712" },
+	{ name = "vitest.config.mjs", text = "", fg = "#4d6712" },
+	{ name = "vitest.config.mts", text = "", fg = "#4d6712" },
+	{ name = "vitest.config.ts", text = "", fg = "#4d6712" },
+	{ name = "vlcrc", text = "󰕼", fg = "#9f5100" },
+	{ name = "webpack", text = "󰜫", fg = "#36677c" },
+	{ name = "weston.ini", text = "", fg = "#805e00" },
+	{ name = "workspace", text = "", fg = "#447028" },
+	{ name = "wrangler.jsonc", text = "", fg = "#a35615" },
+	{ name = "wrangler.toml", text = "", fg = "#a35615" },
+	{ name = "xdph.conf", text = "", fg = "#008082" },
+	{ name = "xmobarrc", text = "", fg = "#a9333e" },
+	{ name = "xmobarrc.hs", text = "", fg = "#a9333e" },
+	{ name = "xmonad.hs", text = "", fg = "#a9333e" },
+	{ name = "xorg.conf", text = "", fg = "#ac3a12" },
+	{ name = "xsettingsd.conf", text = "", fg = "#ac3a12" },
+]
+exts = [
+	{ name = "3gp", text = "", fg = "#7e4c10" },
+	{ name = "3mf", text = "󰆧", fg = "#5b5b5b" },
+	{ name = "7z", text = "", fg = "#76520c" },
+	{ name = "a", text = "", fg = "#494a47" },
+	{ name = "aac", text = "", fg = "#0075aa" },
+	{ name = "ada", text = "", fg = "#3b69aa" },
+	{ name = "adb", text = "", fg = "#3b69aa" },
+	{ name = "ads", text = "", fg = "#6b4d83" },
+	{ name = "ai", text = "", fg = "#666620" },
+	{ name = "aif", text = "", fg = "#0075aa" },
+	{ name = "aiff", text = "", fg = "#0075aa" },
+	{ name = "android", text = "", fg = "#277e3e" },
+	{ name = "ape", text = "", fg = "#0075aa" },
+	{ name = "apk", text = "", fg = "#277e3e" },
+	{ name = "apl", text = "", fg = "#1b7936" },
+	{ name = "app", text = "", fg = "#9f0500" },
+	{ name = "applescript", text = "", fg = "#526064" },
+	{ name = "asc", text = "󰦝", fg = "#41525f" },
+	{ name = "asm", text = "", fg = "#006d8e" },
+	{ name = "ass", text = "󰨖", fg = "#805c0a" },
+	{ name = "astro", text = "", fg = "#aa2f4d" },
+	{ name = "avif", text = "", fg = "#6b4d83" },
+	{ name = "awk", text = "", fg = "#3a4446" },
+	{ name = "azcli", text = "", fg = "#005a9f" },
+	{ name = "bak", text = "󰁯", fg = "#526064" },
+	{ name = "bash", text = "", fg = "#447028" },
+	{ name = "bat", text = "", fg = "#40500f" },
+	{ name = "bazel", text = "", fg = "#447028" },
+	{ name = "bib", text = "󱉟", fg = "#666620" },
+	{ name = "bicep", text = "", fg = "#36677c" },
+	{ name = "bicepparam", text = "", fg = "#6a4d77" },
+	{ name = "bin", text = "", fg = "#9f0500" },
+	{ name = "blade.php", text = "", fg = "#a0372b" },
+	{ name = "blend", text = "󰂫", fg = "#9c4f00" },
+	{ name = "blp", text = "󰺾", fg = "#3a6497" },
+	{ name = "bmp", text = "", fg = "#6b4d83" },
+	{ name = "bqn", text = "", fg = "#1b7936" },
+	{ name = "brep", text = "󰻫", fg = "#576342" },
+	{ name = "bz", text = "", fg = "#76520c" },
+	{ name = "bz2", text = "", fg = "#76520c" },
+	{ name = "bz3", text = "", fg = "#76520c" },
+	{ name = "bzl", text = "", fg = "#447028" },
+	{ name = "c", text = "", fg = "#3b69aa" },
+	{ name = "c++", text = "", fg = "#a23253" },
+	{ name = "cache", text = "", fg = "#333333" },
+	{ name = "cast", text = "", fg = "#7e4c10" },
+	{ name = "cbl", text = "", fg = "#005ca5" },
+	{ name = "cc", text = "", fg = "#a23253" },
+	{ name = "ccm", text = "", fg = "#a23253" },
+	{ name = "cfc", text = "", fg = "#017b8c" },
+	{ name = "cfg", text = "", fg = "#526064" },
+	{ name = "cfm", text = "", fg = "#017b8c" },
+	{ name = "cjs", text = "", fg = "#666620" },
+	{ name = "clj", text = "", fg = "#466024" },
+	{ name = "cljc", text = "", fg = "#466024" },
+	{ name = "cljd", text = "", fg = "#36677c" },
+	{ name = "cljs", text = "", fg = "#36677c" },
+	{ name = "cmake", text = "", fg = "#2c2d2f" },
+	{ name = "cob", text = "", fg = "#005ca5" },
+	{ name = "cobol", text = "", fg = "#005ca5" },
+	{ name = "coffee", text = "", fg = "#666620" },
+	{ name = "conda", text = "", fg = "#2d751c" },
+	{ name = "conf", text = "", fg = "#526064" },
+	{ name = "config.ru", text = "", fg = "#701516" },
+	{ name = "cow", text = "󰆚", fg = "#70421b" },
+	{ name = "cp", text = "", fg = "#36677c" },
+	{ name = "cpp", text = "", fg = "#36677c" },
+	{ name = "cppm", text = "", fg = "#36677c" },
+	{ name = "cpy", text = "", fg = "#005ca5" },
+	{ name = "cr", text = "", fg = "#434343" },
+	{ name = "crdownload", text = "", fg = "#226654" },
+	{ name = "cs", text = "󰌛", fg = "#434d04" },
+	{ name = "csh", text = "", fg = "#3a4446" },
+	{ name = "cshtml", text = "󱦗", fg = "#512bd4" },
+	{ name = "cson", text = "", fg = "#666620" },
+	{ name = "csproj", text = "󰪮", fg = "#512bd4" },
+	{ name = "css", text = "", fg = "#663399" },
+	{ name = "csv", text = "", fg = "#447028" },
+	{ name = "cts", text = "", fg = "#36677c" },
+	{ name = "cu", text = "", fg = "#447028" },
+	{ name = "cue", text = "󰲹", fg = "#764a57" },
+	{ name = "cuh", text = "", fg = "#6b4d83" },
+	{ name = "cxx", text = "", fg = "#36677c" },
+	{ name = "cxxm", text = "", fg = "#36677c" },
+	{ name = "d", text = "", fg = "#842b25" },
+	{ name = "d.ts", text = "", fg = "#6a4c2a" },
+	{ name = "dart", text = "", fg = "#03589c" },
+	{ name = "db", text = "", fg = "#494848" },
+	{ name = "dconf", text = "", fg = "#333333" },
+	{ name = "desktop", text = "", fg = "#563d7c" },
+	{ name = "diff", text = "", fg = "#41535b" },
+	{ name = "dll", text = "", fg = "#4d2c0b" },
+	{ name = "doc", text = "󰈬", fg = "#185abd" },
+	{ name = "Dockerfile", text = "󰡨", fg = "#2e5f99" },
+	{ name = "dockerignore", text = "󰡨", fg = "#2e5f99" },
+	{ name = "docx", text = "󰈬", fg = "#185abd" },
+	{ name = "dot", text = "󱁉", fg = "#244a6a" },
+	{ name = "download", text = "", fg = "#226654" },
+	{ name = "drl", text = "", fg = "#553a3a" },
+	{ name = "dropbox", text = "", fg = "#0049be" },
+	{ name = "dump", text = "", fg = "#494848" },
+	{ name = "dwg", text = "󰻫", fg = "#576342" },
+	{ name = "dxf", text = "󰻫", fg = "#576342" },
+	{ name = "ebook", text = "", fg = "#755836" },
+	{ name = "ebuild", text = "", fg = "#4c416e" },
+	{ name = "edn", text = "", fg = "#36677c" },
+	{ name = "eex", text = "", fg = "#6b4d83" },
+	{ name = "ejs", text = "", fg = "#666620" },
+	{ name = "el", text = "", fg = "#61568e" },
+	{ name = "elc", text = "", fg = "#61568e" },
+	{ name = "elf", text = "", fg = "#9f0500" },
+	{ name = "elm", text = "", fg = "#36677c" },
+	{ name = "eln", text = "", fg = "#61568e" },
+	{ name = "env", text = "", fg = "#32310d" },
+	{ name = "eot", text = "", fg = "#2f2f2f" },
+	{ name = "epp", text = "", fg = "#80530d" },
+	{ name = "epub", text = "", fg = "#755836" },
+	{ name = "erb", text = "", fg = "#701516" },
+	{ name = "erl", text = "", fg = "#8a2b72" },
+	{ name = "ex", text = "", fg = "#6b4d83" },
+	{ name = "exe", text = "", fg = "#9f0500" },
+	{ name = "exs", text = "", fg = "#6b4d83" },
+	{ name = "f#", text = "", fg = "#36677c" },
+	{ name = "f3d", text = "󰻫", fg = "#576342" },
+	{ name = "f90", text = "󱈚", fg = "#563b70" },
+	{ name = "fbx", text = "󰆧", fg = "#5b5b5b" },
+	{ name = "fcbak", text = "", fg = "#98262c" },
+	{ name = "fcmacro", text = "", fg = "#98262c" },
+	{ name = "fcmat", text = "", fg = "#98262c" },
+	{ name = "fcparam", text = "", fg = "#98262c" },
+	{ name = "fcscript", text = "", fg = "#98262c" },
+	{ name = "fcstd", text = "", fg = "#98262c" },
+	{ name = "fcstd1", text = "", fg = "#98262c" },
+	{ name = "fctb", text = "", fg = "#98262c" },
+	{ name = "fctl", text = "", fg = "#98262c" },
+	{ name = "fdmdownload", text = "", fg = "#226654" },
+	{ name = "feature", text = "", fg = "#007e12" },
+	{ name = "fish", text = "", fg = "#3a4446" },
+	{ name = "flac", text = "", fg = "#005880" },
+	{ name = "flc", text = "", fg = "#2f2f2f" },
+	{ name = "flf", text = "", fg = "#2f2f2f" },
+	{ name = "fnl", text = "", fg = "#33312b" },
+	{ name = "fodg", text = "", fg = "#333211" },
+	{ name = "fodp", text = "", fg = "#7f4e22" },
+	{ name = "fods", text = "", fg = "#28541a" },
+	{ name = "fodt", text = "", fg = "#16667e" },
+	{ name = "frag", text = "", fg = "#40647c" },
+	{ name = "fs", text = "", fg = "#36677c" },
+	{ name = "fsi", text = "", fg = "#36677c" },
+	{ name = "fsscript", text = "", fg = "#36677c" },
+	{ name = "fsx", text = "", fg = "#36677c" },
+	{ name = "gcode", text = "󰐫", fg = "#0f5582" },
+	{ name = "gd", text = "", fg = "#526064" },
+	{ name = "gemspec", text = "", fg = "#701516" },
+	{ name = "geom", text = "", fg = "#40647c" },
+	{ name = "gif", text = "", fg = "#6b4d83" },
+	{ name = "git", text = "", fg = "#b5391e" },
+	{ name = "glb", text = "", fg = "#80581e" },
+	{ name = "gleam", text = "", fg = "#553a51" },
+	{ name = "glsl", text = "", fg = "#40647c" },
+	{ name = "gnumakefile", text = "", fg = "#526064" },
+	{ name = "go", text = "", fg = "#0082a2" },
+	{ name = "godot", text = "", fg = "#526064" },
+	{ name = "gpr", text = "", fg = "#526064" },
+	{ name = "gql", text = "", fg = "#ac2880" },
+	{ name = "gradle", text = "", fg = "#005f87" },
+	{ name = "graphql", text = "", fg = "#ac2880" },
+	{ name = "gresource", text = "", fg = "#333333" },
+	{ name = "gv", text = "󱁉", fg = "#244a6a" },
+	{ name = "gz", text = "", fg = "#76520c" },
+	{ name = "h", text = "", fg = "#6b4d83" },
+	{ name = "haml", text = "", fg = "#2f2f2d" },
+	{ name = "hbs", text = "", fg = "#a04f1d" },
+	{ name = "heex", text = "", fg = "#6b4d83" },
+	{ name = "hex", text = "", fg = "#224abf" },
+	{ name = "hh", text = "", fg = "#6b4d83" },
+	{ name = "hpp", text = "", fg = "#6b4d83" },
+	{ name = "hrl", text = "", fg = "#8a2b72" },
+	{ name = "hs", text = "", fg = "#6b4d83" },
+	{ name = "htm", text = "", fg = "#aa391c" },
+	{ name = "html", text = "", fg = "#ab3a1c" },
+	{ name = "http", text = "", fg = "#006a95" },
+	{ name = "huff", text = "󰡘", fg = "#4242c7" },
+	{ name = "hurl", text = "", fg = "#bf0266" },
+	{ name = "hx", text = "", fg = "#9c5715" },
+	{ name = "hxx", text = "", fg = "#6b4d83" },
+	{ name = "ical", text = "", fg = "#2b2e83" },
+	{ name = "icalendar", text = "", fg = "#2b2e83" },
+	{ name = "ico", text = "", fg = "#666620" },
+	{ name = "ics", text = "", fg = "#2b2e83" },
+	{ name = "ifb", text = "", fg = "#2b2e83" },
+	{ name = "ifc", text = "󰻫", fg = "#576342" },
+	{ name = "ige", text = "󰻫", fg = "#576342" },
+	{ name = "iges", text = "󰻫", fg = "#576342" },
+	{ name = "igs", text = "󰻫", fg = "#576342" },
+	{ name = "image", text = "", fg = "#453f43" },
+	{ name = "img", text = "", fg = "#453f43" },
+	{ name = "import", text = "", fg = "#2f2f2f" },
+	{ name = "info", text = "", fg = "#333329" },
+	{ name = "ini", text = "", fg = "#526064" },
+	{ name = "ino", text = "", fg = "#397981" },
+	{ name = "ipynb", text = "", fg = "#a35301" },
+	{ name = "iso", text = "", fg = "#453f43" },
+	{ name = "ixx", text = "", fg = "#36677c" },
+	{ name = "jar", text = "", fg = "#805834" },
+	{ name = "java", text = "", fg = "#992e33" },
+	{ name = "jl", text = "", fg = "#6c4b7c" },
+	{ name = "jpeg", text = "", fg = "#6b4d83" },
+	{ name = "jpg", text = "", fg = "#6b4d83" },
+	{ name = "js", text = "", fg = "#666620" },
+	{ name = "json", text = "", fg = "#666620" },
+	{ name = "json5", text = "", fg = "#666620" },
+	{ name = "jsonc", text = "", fg = "#666620" },
+	{ name = "jsx", text = "", fg = "#158197" },
+	{ name = "jwmrc", text = "", fg = "#005a9a" },
+	{ name = "jxl", text = "", fg = "#6b4d83" },
+	{ name = "kbx", text = "󰯄", fg = "#565856" },
+	{ name = "kdb", text = "", fg = "#3e7427" },
+	{ name = "kdbx", text = "", fg = "#3e7427" },
+	{ name = "kdenlive", text = "", fg = "#425c79" },
+	{ name = "kdenlivetitle", text = "", fg = "#425c79" },
+	{ name = "kicad_dru", text = "", fg = "#333333" },
+	{ name = "kicad_mod", text = "", fg = "#333333" },
+	{ name = "kicad_pcb", text = "", fg = "#333333" },
+	{ name = "kicad_prl", text = "", fg = "#333333" },
+	{ name = "kicad_pro", text = "", fg = "#333333" },
+	{ name = "kicad_sch", text = "", fg = "#333333" },
+	{ name = "kicad_sym", text = "", fg = "#333333" },
+	{ name = "kicad_wks", text = "", fg = "#333333" },
+	{ name = "ko", text = "", fg = "#494a47" },
+	{ name = "kpp", text = "", fg = "#a12ea7" },
+	{ name = "kra", text = "", fg = "#a12ea7" },
+	{ name = "krz", text = "", fg = "#a12ea7" },
+	{ name = "ksh", text = "", fg = "#3a4446" },
+	{ name = "kt", text = "", fg = "#5f3ebf" },
+	{ name = "kts", text = "", fg = "#5f3ebf" },
+	{ name = "lck", text = "", fg = "#5e5e5e" },
+	{ name = "leex", text = "", fg = "#6b4d83" },
+	{ name = "less", text = "", fg = "#563d7c" },
+	{ name = "lff", text = "", fg = "#2f2f2f" },
+	{ name = "lhs", text = "", fg = "#6b4d83" },
+	{ name = "lib", text = "", fg = "#4d2c0b" },
+	{ name = "license", text = "", fg = "#666620" },
+	{ name = "liquid", text = "", fg = "#4a6024" },
+	{ name = "lock", text = "", fg = "#5e5e5e" },
+	{ name = "log", text = "󰌱", fg = "#4a4a4a" },
+	{ name = "lrc", text = "󰨖", fg = "#805c0a" },
+	{ name = "lua", text = "", fg = "#366b8a" },
+	{ name = "luac", text = "", fg = "#366b8a" },
+	{ name = "luau", text = "", fg = "#007abf" },
+	{ name = "m", text = "", fg = "#3b69aa" },
+	{ name = "m3u", text = "󰲹", fg = "#764a57" },
+	{ name = "m3u8", text = "󰲹", fg = "#764a57" },
+	{ name = "m4a", text = "", fg = "#0075aa" },
+	{ name = "m4v", text = "", fg = "#7e4c10" },
+	{ name = "magnet", text = "", fg = "#a51b16" },
+	{ name = "makefile", text = "", fg = "#526064" },
+	{ name = "markdown", text = "", fg = "#4a4a4a" },
+	{ name = "material", text = "", fg = "#8a2b72" },
+	{ name = "md", text = "", fg = "#4a4a4a" },
+	{ name = "md5", text = "󰕥", fg = "#5d5975" },
+	{ name = "mdx", text = "", fg = "#36677c" },
+	{ name = "mint", text = "󰌪", fg = "#44604a" },
+	{ name = "mjs", text = "", fg = "#504b1e" },
+	{ name = "mk", text = "", fg = "#526064" },
+	{ name = "mkv", text = "", fg = "#7e4c10" },
+	{ name = "ml", text = "", fg = "#975122" },
+	{ name = "mli", text = "", fg = "#975122" },
+	{ name = "mm", text = "", fg = "#36677c" },
+	{ name = "mo", text = "", fg = "#654ca7" },
+	{ name = "mobi", text = "", fg = "#755836" },
+	{ name = "mojo", text = "", fg = "#bf3917" },
+	{ name = "mov", text = "", fg = "#7e4c10" },
+	{ name = "mp3", text = "", fg = "#0075aa" },
+	{ name = "mp4", text = "", fg = "#7e4c10" },
+	{ name = "mpp", text = "", fg = "#36677c" },
+	{ name = "msf", text = "", fg = "#0e5ca9" },
+	{ name = "mts", text = "", fg = "#36677c" },
+	{ name = "mustache", text = "", fg = "#975122" },
+	{ name = "nfo", text = "", fg = "#333329" },
+	{ name = "nim", text = "", fg = "#514700" },
+	{ name = "nix", text = "", fg = "#3f5d72" },
+	{ name = "norg", text = "", fg = "#365a8e" },
+	{ name = "nswag", text = "", fg = "#427516" },
+	{ name = "nu", text = "", fg = "#276f4e" },
+	{ name = "o", text = "", fg = "#9f0500" },
+	{ name = "obj", text = "󰆧", fg = "#5b5b5b" },
+	{ name = "odf", text = "", fg = "#aa3c64" },
+	{ name = "odg", text = "", fg = "#333211" },
+	{ name = "odin", text = "󰟢", fg = "#2a629e" },
+	{ name = "odp", text = "", fg = "#7f4e22" },
+	{ name = "ods", text = "", fg = "#28541a" },
+	{ name = "odt", text = "", fg = "#16667e" },
+	{ name = "oga", text = "", fg = "#005880" },
+	{ name = "ogg", text = "", fg = "#005880" },
+	{ name = "ogv", text = "", fg = "#7e4c10" },
+	{ name = "ogx", text = "", fg = "#7e4c10" },
+	{ name = "opus", text = "", fg = "#005880" },
+	{ name = "org", text = "", fg = "#4f7166" },
+	{ name = "otf", text = "", fg = "#2f2f2f" },
+	{ name = "out", text = "", fg = "#9f0500" },
+	{ name = "part", text = "", fg = "#226654" },
+	{ name = "patch", text = "", fg = "#41535b" },
+	{ name = "pck", text = "", fg = "#526064" },
+	{ name = "pcm", text = "", fg = "#005880" },
+	{ name = "pdf", text = "", fg = "#b30b00" },
+	{ name = "php", text = "", fg = "#6b4d83" },
+	{ name = "pl", text = "", fg = "#36677c" },
+	{ name = "pls", text = "󰲹", fg = "#764a57" },
+	{ name = "ply", text = "󰆧", fg = "#5b5b5b" },
+	{ name = "pm", text = "", fg = "#36677c" },
+	{ name = "png", text = "", fg = "#6b4d83" },
+	{ name = "po", text = "", fg = "#1c708e" },
+	{ name = "pot", text = "", fg = "#1c708e" },
+	{ name = "pp", text = "", fg = "#80530d" },
+	{ name = "ppt", text = "󰈧", fg = "#983826" },
+	{ name = "pptx", text = "󰈧", fg = "#983826" },
+	{ name = "prisma", text = "", fg = "#444da2" },
+	{ name = "pro", text = "", fg = "#725c2a" },
+	{ name = "ps1", text = "󰨊", fg = "#325698" },
+	{ name = "psb", text = "", fg = "#36677c" },
+	{ name = "psd", text = "", fg = "#36677c" },
+	{ name = "psd1", text = "󰨊", fg = "#4f5893" },
+	{ name = "psm1", text = "󰨊", fg = "#4f5893" },
+	{ name = "pub", text = "󰷖", fg = "#4c422f" },
+	{ name = "pxd", text = "", fg = "#3c6f98" },
+	{ name = "pxi", text = "", fg = "#3c6f98" },
+	{ name = "py", text = "", fg = "#805e02" },
+	{ name = "pyc", text = "", fg = "#332d1d" },
+	{ name = "pyd", text = "", fg = "#332d1d" },
+	{ name = "pyi", text = "", fg = "#805e02" },
+	{ name = "pyo", text = "", fg = "#332d1d" },
+	{ name = "pyw", text = "", fg = "#3c6f98" },
+	{ name = "pyx", text = "", fg = "#3c6f98" },
+	{ name = "qm", text = "", fg = "#1c708e" },
+	{ name = "qml", text = "", fg = "#2b8937" },
+	{ name = "qrc", text = "", fg = "#2b8937" },
+	{ name = "qss", text = "", fg = "#2b8937" },
+	{ name = "query", text = "", fg = "#607035" },
+	{ name = "R", text = "󰟔", fg = "#1a4c8c" },
+	{ name = "r", text = "󰟔", fg = "#1a4c8c" },
+	{ name = "rake", text = "", fg = "#701516" },
+	{ name = "rar", text = "", fg = "#76520c" },
+	{ name = "rasi", text = "", fg = "#666620" },
+	{ name = "razor", text = "󱦘", fg = "#512bd4" },
+	{ name = "rb", text = "", fg = "#701516" },
+	{ name = "res", text = "", fg = "#992e33" },
+	{ name = "resi", text = "", fg = "#a33759" },
+	{ name = "rlib", text = "", fg = "#6f5242" },
+	{ name = "rmd", text = "", fg = "#36677c" },
+	{ name = "rproj", text = "󰗆", fg = "#286844" },
+	{ name = "rs", text = "", fg = "#6f5242" },
+	{ name = "rss", text = "", fg = "#7e4e1e" },
+	{ name = "s", text = "", fg = "#005594" },
+	{ name = "sass", text = "", fg = "#a33759" },
+	{ name = "sbt", text = "", fg = "#992e33" },
+	{ name = "sc", text = "", fg = "#992e33" },
+	{ name = "scad", text = "", fg = "#53480f" },
+	{ name = "scala", text = "", fg = "#992e33" },
+	{ name = "scm", text = "󰘧", fg = "#303030" },
+	{ name = "scss", text = "", fg = "#a33759" },
+	{ name = "sh", text = "", fg = "#3a4446" },
+	{ name = "sha1", text = "󰕥", fg = "#5d5975" },
+	{ name = "sha224", text = "󰕥", fg = "#5d5975" },
+	{ name = "sha256", text = "󰕥", fg = "#5d5975" },
+	{ name = "sha384", text = "󰕥", fg = "#5d5975" },
+	{ name = "sha512", text = "󰕥", fg = "#5d5975" },
+	{ name = "sig", text = "󰘧", fg = "#975122" },
+	{ name = "signature", text = "󰘧", fg = "#975122" },
+	{ name = "skp", text = "󰻫", fg = "#576342" },
+	{ name = "sldasm", text = "󰻫", fg = "#576342" },
+	{ name = "sldprt", text = "󰻫", fg = "#576342" },
+	{ name = "slim", text = "", fg = "#aa391c" },
+	{ name = "sln", text = "", fg = "#643995" },
+	{ name = "slnx", text = "", fg = "#643995" },
+	{ name = "slvs", text = "󰻫", fg = "#576342" },
+	{ name = "sml", text = "󰘧", fg = "#975122" },
+	{ name = "so", text = "", fg = "#494a47" },
+	{ name = "sol", text = "", fg = "#36677c" },
+	{ name = "spec.js", text = "", fg = "#666620" },
+	{ name = "spec.jsx", text = "", fg = "#158197" },
+	{ name = "spec.ts", text = "", fg = "#36677c" },
+	{ name = "spec.tsx", text = "", fg = "#1354bf" },
+	{ name = "spx", text = "", fg = "#005880" },
+	{ name = "sql", text = "", fg = "#494848" },
+	{ name = "sqlite", text = "", fg = "#494848" },
+	{ name = "sqlite3", text = "", fg = "#494848" },
+	{ name = "srt", text = "󰨖", fg = "#805c0a" },
+	{ name = "ssa", text = "󰨖", fg = "#805c0a" },
+	{ name = "ste", text = "󰻫", fg = "#576342" },
+	{ name = "step", text = "󰻫", fg = "#576342" },
+	{ name = "stl", text = "󰆧", fg = "#5b5b5b" },
+	{ name = "stories.js", text = "", fg = "#aa2f59" },
+	{ name = "stories.jsx", text = "", fg = "#aa2f59" },
+	{ name = "stories.mjs", text = "", fg = "#aa2f59" },
+	{ name = "stories.svelte", text = "", fg = "#aa2f59" },
+	{ name = "stories.ts", text = "", fg = "#aa2f59" },
+	{ name = "stories.tsx", text = "", fg = "#aa2f59" },
+	{ name = "stories.vue", text = "", fg = "#aa2f59" },
+	{ name = "stp", text = "󰻫", fg = "#576342" },
+	{ name = "strings", text = "", fg = "#1c708e" },
+	{ name = "styl", text = "", fg = "#466024" },
+	{ name = "sub", text = "󰨖", fg = "#805c0a" },
+	{ name = "sublime", text = "", fg = "#975122" },
+	{ name = "suo", text = "", fg = "#643995" },
+	{ name = "sv", text = "󰍛", fg = "#017226" },
+	{ name = "svelte", text = "", fg = "#bf2e00" },
+	{ name = "svg", text = "󰜡", fg = "#80581e" },
+	{ name = "svgz", text = "󰜡", fg = "#80581e" },
+	{ name = "svh", text = "󰍛", fg = "#017226" },
+	{ name = "swift", text = "", fg = "#975122" },
+	{ name = "t", text = "", fg = "#36677c" },
+	{ name = "tbc", text = "󰛓", fg = "#1e5cb3" },
+	{ name = "tcl", text = "󰛓", fg = "#1e5cb3" },
+	{ name = "templ", text = "", fg = "#6e5e18" },
+	{ name = "terminal", text = "", fg = "#217929" },
+	{ name = "test.js", text = "", fg = "#666620" },
+	{ name = "test.jsx", text = "", fg = "#158197" },
+	{ name = "test.ts", text = "", fg = "#36677c" },
+	{ name = "test.tsx", text = "", fg = "#1354bf" },
+	{ name = "tex", text = "", fg = "#3d6117" },
+	{ name = "tf", text = "", fg = "#4732af" },
+	{ name = "tfvars", text = "", fg = "#4732af" },
+	{ name = "tgz", text = "", fg = "#76520c" },
+	{ name = "tmpl", text = "", fg = "#6e5e18" },
+	{ name = "tmux", text = "", fg = "#0f8c13" },
+	{ name = "toml", text = "", fg = "#753219" },
+	{ name = "torrent", text = "", fg = "#226654" },
+	{ name = "tres", text = "", fg = "#526064" },
+	{ name = "ts", text = "", fg = "#36677c" },
+	{ name = "tscn", text = "", fg = "#526064" },
+	{ name = "tsconfig", text = "", fg = "#aa5a00" },
+	{ name = "tsx", text = "", fg = "#1354bf" },
+	{ name = "ttf", text = "", fg = "#2f2f2f" },
+	{ name = "twig", text = "", fg = "#466024" },
+	{ name = "txt", text = "󰈙", fg = "#447028" },
+	{ name = "txz", text = "", fg = "#76520c" },
+	{ name = "typ", text = "", fg = "#097d80" },
+	{ name = "typoscript", text = "", fg = "#aa5a00" },
+	{ name = "ui", text = "", fg = "#015bf0" },
+	{ name = "v", text = "󰍛", fg = "#017226" },
+	{ name = "vala", text = "", fg = "#5c2e8b" },
+	{ name = "vert", text = "", fg = "#40647c" },
+	{ name = "vh", text = "󰍛", fg = "#017226" },
+	{ name = "vhd", text = "󰍛", fg = "#017226" },
+	{ name = "vhdl", text = "󰍛", fg = "#017226" },
+	{ name = "vi", text = "", fg = "#554203" },
+	{ name = "vim", text = "", fg = "#017226" },
+	{ name = "vsh", text = "", fg = "#3e5a7f" },
+	{ name = "vsix", text = "", fg = "#643995" },
+	{ name = "vue", text = "", fg = "#466024" },
+	{ name = "wasm", text = "", fg = "#4539a4" },
+	{ name = "wav", text = "", fg = "#0075aa" },
+	{ name = "webm", text = "", fg = "#7e4c10" },
+	{ name = "webmanifest", text = "", fg = "#504b1e" },
+	{ name = "webp", text = "", fg = "#6b4d83" },
+	{ name = "webpack", text = "󰜫", fg = "#36677c" },
+	{ name = "wma", text = "", fg = "#0075aa" },
+	{ name = "wmv", text = "", fg = "#7e4c10" },
+	{ name = "woff", text = "", fg = "#2f2f2f" },
+	{ name = "woff2", text = "", fg = "#2f2f2f" },
+	{ name = "wrl", text = "󰆧", fg = "#5b5b5b" },
+	{ name = "wrz", text = "󰆧", fg = "#5b5b5b" },
+	{ name = "wv", text = "", fg = "#0075aa" },
+	{ name = "wvc", text = "", fg = "#0075aa" },
+	{ name = "x", text = "", fg = "#3b69aa" },
+	{ name = "xaml", text = "󰙳", fg = "#512bd4" },
+	{ name = "xcf", text = "", fg = "#4a4434" },
+	{ name = "xcplayground", text = "", fg = "#975122" },
+	{ name = "xcstrings", text = "", fg = "#1c708e" },
+	{ name = "xls", text = "󰈛", fg = "#207245" },
+	{ name = "xlsx", text = "󰈛", fg = "#207245" },
+	{ name = "xm", text = "", fg = "#36677c" },
+	{ name = "xml", text = "󰗀", fg = "#975122" },
+	{ name = "xpi", text = "", fg = "#bf1401" },
+	{ name = "xslt", text = "󰗀", fg = "#227193" },
+	{ name = "xul", text = "", fg = "#975122" },
+	{ name = "xz", text = "", fg = "#76520c" },
+	{ name = "yaml", text = "", fg = "#526064" },
+	{ name = "yml", text = "", fg = "#526064" },
+	{ name = "zig", text = "", fg = "#7b4d0e" },
+	{ name = "zip", text = "", fg = "#76520c" },
+	{ name = "zsh", text = "", fg = "#447028" },
+	{ name = "zst", text = "", fg = "#76520c" },
+	{ name = "🔥", text = "", fg = "#bf3917" },
+]
+conds = [
+	# Special files
+	{ if = "orphan", text = "", fg = "#000000" },
+	{ if = "link", text = "", fg = "#9e9e9e" },
+	{ if = "block", text = "", fg = "#ffc107" },
+	{ if = "char", text = "", fg = "#ffc107" },
+	{ if = "fifo", text = "", fg = "#ffc107" },
+	{ if = "sock", text = "", fg = "#ffc107" },
+	{ if = "sticky", text = "", fg = "#ffc107" },
+	{ if = "dummy", text = "", fg = "#f44336" },
+
+	# Fallback
+	{ if = "dir & hovered", text = "", fg = "#03a9f4" },
+	{ if = "dir", text = "", fg = "#03a9f4" },
+	{ if = "exec", text = "", fg = "#8bc34a" },
+	{ if = "!dir", text = "", fg = "#000000" },
+]
+
+# : }}}

--- a/src/components/Default/yazi-default.toml
+++ b/src/components/Default/yazi-default.toml
@@ -1,0 +1,247 @@
+# A TOML linter such as https://github.com/tombi-toml/tombi can use this schema to validate your config.
+# If you encounter any issues, please make an issue at https://github.com/yazi-rs/schemas.
+
+#:schema https://yazi-rs.github.io/schemas/yazi.json
+
+[mgr]
+ratio          = [ 1, 4, 3 ]
+sort_by        = "alphabetical"
+sort_sensitive = false
+sort_reverse 	 = false
+sort_dir_first = true
+sort_translit  = false
+sort_fallback  = "alphabetical"
+linemode       = "none"
+show_hidden    = false
+show_symlink   = true
+scrolloff      = 5
+mouse_events   = [ "click", "scroll", "drag" ]
+
+[preview]
+wrap            = "no"
+tab_size        = 2
+max_width       = 600
+max_height      = 900
+cache_dir       = ""
+image_delay     = 30
+image_filter    = "triangle"
+image_quality   = 75
+ueberzug_scale  = 1
+ueberzug_offset = [ 0, 0, 0, 0 ]
+
+[opener]
+edit = [
+	{ run = "${EDITOR:-vi} %s", desc = "$EDITOR",      for = "unix", block = true },
+	{ run = "code %s",          desc = "code",         for = "windows", orphan = true },
+	{ run = "code -w %s",       desc = "code (block)", for = "windows", block = true },
+]
+play = [
+	{ run = "xdg-open %s1",    desc = "Play", for = "linux", orphan = true },
+	{ run = "open %s",         desc = "Play", for = "macos" },
+	{ run = 'start "" %s1',    desc = "Play", for = "windows", orphan = true },
+	{ run = "termux-open %s1", desc = "Play", for = "android" },
+	{ run = "mediainfo %s1; echo 'Press enter to exit'; read _", block = true, desc = "Show media info", for = "unix" },
+	{ run = "mediainfo %s1 & pause", block = true, desc = "Show media info", for = "windows" },
+]
+open = [
+	{ run = "xdg-open %s1",    desc = "Open", for = "linux" },
+	{ run = "open %s",         desc = "Open", for = "macos" },
+	{ run = 'start "" %s1',    desc = "Open", for = "windows", orphan = true },
+	{ run = "termux-open %s1", desc = "Open", for = "android" },
+]
+reveal = [
+	{ run = "xdg-open %d1",         desc = "Reveal", for = "linux" },
+	{ run = "open -R %s1",          desc = "Reveal", for = "macos" },
+	{ run = "explorer /select,%s1", desc = "Reveal", for = "windows", orphan = true },
+	{ run = "termux-open %d1",      desc = "Reveal", for = "android" },
+	{ run = "clear; exiftool %s1; echo 'Press enter to exit'; read _", desc = "Show EXIF", for = "unix", block = true },
+]
+extract = [
+	{ run = "ya pub extract --list %s", desc = "Extract here" },
+]
+download = [
+	{ run = "ya emit download --open %S", desc = "Download and open" },
+	{ run = "ya emit download %S",        desc = "Download" },
+]
+
+[open]
+rules = [
+	# Folder
+	{ url = "*/", use = [ "edit", "open", "reveal" ] },
+	# Text
+	{ mime = "text/*", use = [ "edit", "reveal" ] },
+	# Image
+	{ mime = "image/*", use = [ "open", "reveal" ] },
+	# Media
+	{ mime = "{audio,video}/*", use = [ "play", "reveal" ] },
+	# Code
+	{ mime = "application/{json,ndjson,javascript,wine-extension-ini}", use = [ "edit", "reveal" ] },
+	# Archive
+	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", use = [ "extract", "reveal" ] },
+	# Empty file
+	{ mime = "inode/empty", use = [ "edit", "reveal" ] },
+	# Virtual file system
+	{ mime = "vfs/{absent,stale}", use = "download" },
+	# Fallback
+	{ url = "*", use = [ "open", "reveal" ] },
+]
+
+[tasks]
+file_workers     = 3
+plugin_workers   = 5
+fetch_workers    = 5
+preload_workers  = 2
+process_workers  = 5
+bizarre_retry    = 3
+image_alloc      = 536870912  # 512MB
+image_bound      = [ 10000, 10000 ]
+suppress_preload = false
+
+[plugin]
+fetchers = [
+	# MIME-type
+	{ url = "*/",         run = "mime.dir",    prio = "high", group = "mime" },
+	{ url = "local://*",  run = "mime.local",  prio = "high", group = "mime" },
+	{ url = "remote://*", run = "mime.remote", prio = "high", group = "mime" },
+]
+spotters = [
+	# Multi-file
+	{ mime = "multi/*", run = "multi" },
+	# Folder
+	{ url = "*/", run = "folder" },
+	# Code
+	{ mime = "text/*", run = "code" },
+	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
+	# Image
+	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
+	{ mime = "image/svg+xml", run = "svg" },
+	{ mime = "image/*", run = "image" },
+	# Video
+	{ mime = "video/*", run = "video" },
+	# Virtual file system
+	{ mime = "vfs/*", run = "vfs" },
+	# Error
+	{ mime = "null/*", run = "null" },
+	# Fallback
+	{ url = "*", run = "file" },
+]
+preloaders = [
+	# Image
+	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
+	{ mime = "image/svg+xml", run = "svg" },
+	{ mime = "image/*", run = "image" },
+	# Video
+	{ mime = "video/*", run = "video" },
+	# PDF
+	{ mime = "application/pdf", run = "pdf" },
+	# Font
+	{ mime = "font/*", run = "font" },
+	{ mime = "application/ms-opentype", run = "font" },
+]
+previewers = [
+	{ url = "*/", run = "folder" },
+	# Code
+	{ mime = "text/*", run = "code" },
+	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
+	# JSON
+	{ mime = "application/{json,ndjson}", run = "json" },
+	# Image
+	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
+	{ mime = "image/svg+xml", run = "svg" },
+	{ mime = "image/*", run = "image" },
+	# Video
+	{ mime = "video/*", run = "video" },
+	# PDF
+	{ mime = "application/pdf", run = "pdf" },
+	# Archive
+	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", run = "archive" },
+	{ mime = "application/{debian*-package,redhat-package-manager,rpm,android.package-archive}", run = "archive" },
+	{ url = "*.{AppImage,appimage}", run = "archive" },
+	# Virtual Disk / Disk Image
+	{ mime = "application/{iso9660-image,qemu-disk,ms-wim,apple-diskimage}", run = "archive" },
+	{ mime = "application/virtualbox-{vhd,vhdx}", run = "archive" },
+	{ url = "*.{img,fat,ext,ext2,ext3,ext4,squashfs,ntfs,hfs,hfsx}", run = "archive" },
+	# Font
+	{ mime = "font/*", run = "font" },
+	{ mime = "application/ms-opentype", run = "font" },
+	# Empty file
+	{ mime = "inode/empty", run = "empty" },
+	# Virtual file system
+	{ mime = "vfs/*", run = "vfs" },
+	# Error
+	{ mime = "null/*", run = "null" },
+	# Fallback
+	{ url = "*", run = "file" },
+]
+
+[input]
+cursor_blink = false
+
+# cd
+cd_title  = "Change directory:"
+cd_origin = "top-center"
+cd_offset = [ 0, 2, 50, 3 ]
+
+# create
+create_title  = [ "Create:", "Create (dir):" ]
+create_origin = "top-center"
+create_offset = [ 0, 2, 50, 3 ]
+
+# rename
+rename_title  = "Rename:"
+rename_origin = "hovered"
+rename_offset = [ 0, 1, 50, 3 ]
+
+# filter
+filter_title  = "Filter:"
+filter_origin = "top-center"
+filter_offset = [ 0, 2, 50, 3 ]
+
+# find
+find_title  = [ "Find next:", "Find previous:" ]
+find_origin = "top-center"
+find_offset = [ 0, 2, 50, 3 ]
+
+# search
+search_title  = "Search via {n}:"
+search_origin = "top-center"
+search_offset = [ 0, 2, 50, 3 ]
+
+# shell
+shell_title  = [ "Shell:", "Shell (block):" ]
+shell_origin = "top-center"
+shell_offset = [ 0, 2, 50, 3 ]
+
+[confirm]
+# trash
+trash_title 	= "Trash {n} selected file{s}?"
+trash_origin	= "center"
+trash_offset	= [ 0, 0, 70, 20 ]
+
+# delete
+delete_title 	= "Permanently delete {n} selected file{s}?"
+delete_origin	= "center"
+delete_offset	= [ 0, 0, 70, 20 ]
+
+# overwrite
+overwrite_title  = "Overwrite file?"
+overwrite_body   = "Will overwrite the following file:"
+overwrite_origin = "center"
+overwrite_offset = [ 0, 0, 50, 15 ]
+
+# quit
+quit_title  = "Quit?"
+quit_body   = "There are unfinished tasks, quit anyway?\n(Open task manager with default key 'w')"
+quit_origin = "center"
+quit_offset = [ 0, 0, 50, 15 ]
+
+[pick]
+open_title  = "Open with:"
+open_origin = "hovered"
+open_offset = [ 0, 1, 50, 7 ]
+
+[which]
+sort_by      	 = "none"
+sort_sensitive = false
+sort_reverse 	 = false
+sort_translit  = false

--- a/versioned_docs/version-26.5.6/configuration/keymap.md
+++ b/versioned_docs/version-26.5.6/configuration/keymap.md
@@ -3,6 +3,7 @@ sidebar_position: 2
 description: Learn how to configure keyboard shortcuts with Yazi.
 ---
 
+import Default, {Defaults, DefaultWithProp} from "@site/src/components/Default";
 import KeymapArrow from './keymap-arrow.md'
 
 # keymap.toml
@@ -158,6 +159,8 @@ Cancel find, exit visual mode, clear selected, cancel filter, or cancel search.
 
 Automatically determine the operation by default, and it will only execute the selected operation after specifying the option; multiple options can be stacked.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="escape"/>
+
 ### `quit` {#mgr.quit}
 
 Exit the process.
@@ -166,6 +169,8 @@ Exit the process.
 | --------------- | ------------------------------------------------------------------------------ |
 | `--code=[n]`    | Exit code.                                                                     |
 | `--no-cwd-file` | Don't output the current directory to the file specified by `yazi --cwd-file`. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="quit"/>
 
 ### `close` {#mgr.close}
 
@@ -176,31 +181,45 @@ Close the current tab; if it's the last tab, exit the process instead.
 | `--code=[n]`    | Exit code used when exiting.                                                           |
 | `--no-cwd-file` | Don't output the current directory to the file specified by `yazi --cwd-file` on exit. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="close"/>
+
 ### `suspend` {#mgr.suspend}
 
 Pauses Yazi and returns to the parent shell to continue with other tasks.
 
 Once those tasks are done, use the `fg` command of the shell to send a resume signal and return back to Yazi.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="suspend"/>
+
 ### `arrow` {#mgr.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="arrow"/>
 
 ### `leave` {#mgr.leave}
 
 Go back to the parent directory of the hovered file, or the parent of the current working directory if no file is hovered on.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="leave"/>
+
 ### `enter` {#mgr.enter}
 
 Enter the child directory.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="enter"/>
 
 ### `back` {#mgr.back}
 
 Go back to the previous directory.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="back"/>
+
 ### `forward` {#mgr.forward}
 
 Go forward to the next directory.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="forward"/>
 
 ### `seek` {#mgr.seek}
 
@@ -210,9 +229,13 @@ Scroll the contents in the preview panel.
 | --------------- | ---------------------------------------------------------------- |
 | `[n]`           | Use negative values to seek up and positive values to seek down. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="seek"/>
+
 ### `spot` {#mgr.spot}
 
 Display file information with the preset or user-customized spotter.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="spot"/>
 
 ### `cd` {#mgr.cd}
 
@@ -253,9 +276,13 @@ desc = 'Cd to E:\Pictures'
 
 Check out the [resources page](/docs/resources) for a more comprehensive bookmark plugin.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="cd"/>
+
 ### `follow` {#mgr.follow}
 
 Follow the hovered file if it's a symbolic link.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="follow"/>
 
 ### `reveal` {#mgr.reveal}
 
@@ -267,6 +294,8 @@ If the file is not in the current directory, it will change the current director
 | --------------- | ------------------ |
 | `[url]`         | The URL to reveal. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="reveal"/>
+
 ### `toggle` {#mgr.toggle}
 
 Toggle the selection state of the hovered file.
@@ -276,6 +305,8 @@ Toggle the selection state of the hovered file.
 | N/A             | Reverse the selection. |
 | `--state=on`    | Select the file.       |
 | `--state=off`   | Deselect the file.     |
+
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^toggle[^_]"/>
 
 ### `toggle_all` {#mgr.toggle_all}
 
@@ -289,6 +320,8 @@ Toggle the selection state of all files in the current working directory.
 
 Note that `toggle_all --state=off` only deselect the files in CWD, if you have selected files across multiple directories, and want to deselect all of them, use [`escape --select`](#mgr.escape).
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="toggle_all"/>
+
 ### `visual_mode` {#mgr.visual_mode}
 
 Enter visual mode.
@@ -297,6 +330,8 @@ Enter visual mode.
 | --------------- | --------------- |
 | N/A             | Selection mode. |
 | `--unset`       | Unset mode.     |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="visual_mode"/>
 
 ### `open` {#mgr.open}
 
@@ -307,6 +342,8 @@ Open the selected files using [the rules in `[open]`](/docs/configuration/yazi#o
 | `--interactive` | Open the hovered/selected file(s) with an interactive UI to choose the opening method. |
 | `--hovered`     | Always open the hovered file regardless of the selection state.                        |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="open"/>
+
 ### `yank` {#mgr.yank}
 
 Yank the selected files.
@@ -316,9 +353,13 @@ Yank the selected files.
 | N/A             | Copy mode.  |
 | `--cut`         | Cut mode.   |
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^yank"/>
+
 ### `unyank` {#mgr.unyank}
 
 Cancel the yank status of files.
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="^unyank"/>
 
 ### `paste` {#mgr.paste}
 
@@ -329,6 +370,8 @@ Paste the yanked files.
 | `--force`       | Overwrite the destination file if it exists.                                                                 |
 | `--follow`      | Copy the file pointed to by the symbolic link, rather than the link itself. Only can be used during copying. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="paste"/>
+
 ### `link` {#mgr.link}
 
 Create a symbolic link to the yanked files. (This is a privileged action on Windows and must be run as an administrator.)
@@ -338,6 +381,8 @@ Create a symbolic link to the yanked files. (This is a privileged action on Wind
 | `--relative`    | Use a relative path for the symbolic link.   |
 | `--force`       | Overwrite the destination file if it exists. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^link"/>
+
 ### `hardlink` {#mgr.hardlink}
 
 Hardlink the yanked files.
@@ -346,6 +391,8 @@ Hardlink the yanked files.
 | --------------- | ------------------------------------------------------------------------ |
 | `--force`       | Overwrite the destination file if it exists.                             |
 | `--follow`      | Hardlink the file pointed to by a symbolic link, not the symlink itself. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="hardlink"/>
 
 ### `remove` {#mgr.remove}
 
@@ -359,6 +406,8 @@ In the Android platform, you can only use it with the `--permanently` option, si
 | `--permanently` | Permanently delete the files.                                        |
 | `--hovered`     | Always remove the hovered file regardless of the selection state.    |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="remove"/>
+
 ### `create` {#mgr.create}
 
 Create a file or directory. Ends with `/` (Unix) or `\` (Windows) for directories.
@@ -367,6 +416,8 @@ Create a file or directory. Ends with `/` (Unix) or `\` (Windows) for directorie
 | --------------- | ---------------------------------------------------------------------------------------------- |
 | `--dir`         | Always create directories, regardless of whether end with `/` or `\`.                          |
 | `--force`       | Overwrite the destination file directly if it exists, without showing the confirmation dialog. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^create"/>
 
 ### `rename` {#mgr.rename}
 
@@ -387,6 +438,8 @@ Rename a file or directory, or bulk rename if multiple files are selected (`$EDI
 You can also use `--cursor` with `--empty`, for example, `rename --empty=stem --cursor=start` will empty the file's stem, and move the cursor to the start.
 
 Which causes the input box content for the filename `foo.jpg` to be `|.jpg`, where "|" represents the cursor position.
+
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^rename"/>
 
 ### `copy` {#mgr.copy}
 
@@ -413,6 +466,8 @@ Copy the URL of files or directories that are selected or hovered on.
 | -------- | ------------------------------------------------------------------- |
 | N/A      | Platform-specific separator, e.g. `\` for Windows and `/` for Unix. |
 | `"unix"` | Use `/` for all platforms.                                          |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="copy"/>
 
 ### `shell` {#mgr.shell}
 
@@ -455,6 +510,8 @@ desc = "Trash selected files"
 
 For complex shell scripts, you can use TOML's basic strings (`'''` or `"""`) to write them in multiple lines, as demonstrated in [this tip](/docs/tips#email-selected-files).
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="shell"/>
+
 ### `hidden` {#mgr.hidden}
 
 Set the visibility of hidden files.
@@ -464,6 +521,8 @@ Set the visibility of hidden files.
 | `"show"`        | Show hidden files.       |
 | `"hide"`        | Hide hidden files.       |
 | `"toggle"`      | Toggle the hidden state. |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="hidden"/>
 
 ### `linemode` {#mgr.linemode}
 
@@ -477,6 +536,8 @@ Set the [line mode](/docs/configuration/yazi#mgr.linemode).
 | `"mtime"`       | Display the last modified time of the file.                                                                                                                                                         |
 | `"permissions"` | Display the permissions of the file, only available on Unix-like systems.                                                                                                                           |
 | `"owner"`       | Display the owner of the file, only available on Unix-like systems.                                                                                                                                 |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="linemode"/>
 
 ### `search` {#mgr.search}
 
@@ -506,6 +567,8 @@ desc = "Switch to the flat view with a max depth of 3"
 [rg]: https://github.com/BurntSushi/ripgrep
 [rga]: https://github.com/phiresky/ripgrep-all
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="^search"/>
+
 ### `find` {#mgr.find}
 
 Find files in the current working directory interactively and incrementally.
@@ -516,6 +579,8 @@ Find files in the current working directory interactively and incrementally.
 | `--smart`       | Use smart-case when finding, i.e. case-sensitive if the query contains uppercase characters, otherwise case-insensitive. |
 | `--insensitive` | Use case-insensitive find.                                                                                               |
 
+<DefaultWithProp id="mgr.keymap" prop="run" regex="find[^_]"/>
+
 ### `find_arrow` {#mgr.find_arrow}
 
 Move the cursor to the next or previous occurrence.
@@ -524,12 +589,16 @@ Move the cursor to the next or previous occurrence.
 | --------------- | -------------------------------- |
 | `--previous`    | Move to the previous occurrence. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="find_arrow"/>
+
 ### `filter` {#mgr.filter}
 
 | Argument/Option | Description                                                                                                           |
 | --------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `--smart`       | Filter with smart-case, i.e. case-sensitive if the keyword contains uppercase characters, otherwise case-insensitive. |
 | `--insensitive` | Use case-insensitive filter.                                                                                          |
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="filter"/>
 
 ### `sort` {#mgr.sort}
 
@@ -546,6 +615,8 @@ Move the cursor to the next or previous occurrence.
 - `--dir-first`: Display directories first. `--dir-first` or `--dir-first=yes` to enable, `--dir-first=no` to disable.
 - `--translit`: Transliterate filenames for sorting, see [sort_translit](/docs/configuration/yazi#mgr.sort_translit) for details. `--translit` or `--translit=yes` to enable, `--translit=no` to disable.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="sort"/>
+
 ### `tab_create` {#mgr.tab_create}
 
 | Argument/Option | Description                                         |
@@ -555,6 +626,8 @@ Move the cursor to the next or previous occurrence.
 
 If neither `[url]` nor `--current` is specified, will use the startup directory to create the tab.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_create"/>
+
 ### `tab_close` {#mgr.tab_close}
 
 | Argument/Option | Description                                     |
@@ -563,6 +636,8 @@ If neither `[url]` nor `--current` is specified, will use the startup directory 
 
 If you want to close the current tab, use the [`close`](/docs/configuration/keymap/#mgr.close) action instead.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_close"/>
+
 ### `tab_switch` {#mgr.tab_switch}
 
 | Argument/Option | Description                                                                                                              |
@@ -570,19 +645,27 @@ If you want to close the current tab, use the [`close`](/docs/configuration/keym
 | `[n]`           | Switch to the tab at position `n`, starting from 0.                                                                      |
 | `--relative`    | Switch to the tab at a position relative to the current tab. The value of `n` can be negative when using this parameter. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_switch"/>
+
 ### `tab_swap` {#mgr.tab_swap}
 
 | Argument/Option | Description                                                                                                                          |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `[n]`           | Swap the current tab with the tab at position `n`, where negative values move the tab forward, and positive values move it backward. |
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tab_swap"/>
+
 ### `help` {#mgr.help}
 
 Open the help menu.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="help"/>
+
 ### `plugin` {#mgr.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="mgr.keymap" prop="run" value="plugin"/>
 
 ### `noop` {#mgr.noop}
 
@@ -606,19 +689,27 @@ run = [ "noop" ]  # The array can only have one element and must be "noop"
 
 The disabled keys won't trigger any actions when pressed and won't show up in the `which` component.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="noop"/>
+
 ## [tasks] {#tasks}
 
 ### `show` {#tasks.show}
 
 Show the task manager.
 
+<DefaultWithProp id="mgr.keymap" prop="run" value="tasks:show"/>
+
 ### `close` {#tasks.close}
 
 Hide the task manager.
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="close"/>
+
 ### `arrow` {#tasks.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="tasks.keymap" prop="run" value="arrow"/>
 
 ### `inspect` {#tasks.inspect}
 
@@ -630,37 +721,54 @@ Inspect the task log:
 
 press `q` to exit the inspect view.
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="inspect"/>
+
 ### `cancel` {#tasks.cancel}
 
 Cancel the task.
+
+<DefaultWithProp id="tasks.keymap" prop="run" value="cancel"/>
 
 ### `help` {#tasks.help}
 
 Open the help menu.
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="help"/>
+
 ### `plugin` {#tasks.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="tasks.keymap" prop="run" value="plugin"/>
 
 ### `noop` {#tasks.noop}
 
 See [`noop` action](#mgr.noop).
 
+<DefaultWithProp id="tasks.keymap" prop="run" value="noop"/>
+
 ## [spot] {#spot}
+
 
 ### `close` {#spot.close}
 
 Hide the spotter.
 
+<DefaultWithProp id="spot.keymap" prop="run" value="close"/>
+
 ### `arrow` {#spot.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="spot.keymap" prop="run" value="arrow"/>
 
 ### `swipe` {#spot.swipe}
 
 | Argument/Option | Description                                                                                  |
 | --------------- | -------------------------------------------------------------------------------------------- |
 | `[n]`           | Swipe `n` files up or down in the file list. Negative value for up, positive value for down. |
+
+<DefaultWithProp id="spot.keymap" prop="run" value="swipe"/>
 
 ### `copy` {#spot.copy}
 
@@ -670,17 +778,25 @@ Copy the content from the spotter.
 | --------------- | ---------------------------- |
 | `"cell"`        | Copy the selected table cell |
 
+<DefaultWithProp id="spot.keymap" prop="run" value="copy"/>
+
 ### `plugin` {#spot.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="spot.keymap" prop="run" value="plugin"/>
 
 ### `noop` {#spot.noop}
 
 See [`noop` action](#mgr.noop).
 
+<DefaultWithProp id="spot.keymap" prop="run" value="noop"/>
+
 ### `help` {#spot.help}
 
 Open the help menu.
+
+<DefaultWithProp id="spot.keymap" prop="run" value="help"/>
 
 ## [pick] {#pick}
 
@@ -692,21 +808,31 @@ Cancel the picker.
 | --------------- | ------------------ |
 | `--submit`      | Submit the picker. |
 
+<DefaultWithProp id="pick.keymap" prop="run" value="close"/>
+
 ### `arrow` {#pick.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="pick.keymap" prop="run" value="arrow"/>
 
 ### `help` {#pick.help}
 
 Open the help menu.
 
+<DefaultWithProp id="pick.keymap" prop="run" value="help"/>
+
 ### `plugin` {#pick.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
+<DefaultWithProp id="pick.keymap" prop="run" value="plugin"/>
+
 ### `noop` {#pick.noop}
 
 See [`noop` action](#mgr.noop).
+
+<DefaultWithProp id="pick.keymap" prop="run" value="noop"/>
 
 ## [input] {#input}
 
@@ -718,9 +844,13 @@ Cancel input.
 | --------------- | ----------------- |
 | `--submit`      | Submit the input. |
 
+<DefaultWithProp id="input.keymap" prop="run" value="close"/>
+
 ### `escape` {#input.escape}
 
 Go back the normal mode, or cancel input.
+
+<DefaultWithProp id="input.keymap" prop="run" value="escape"/>
 
 ### `move` {#input.move}
 
@@ -731,9 +861,13 @@ Move the cursor left or right.
 | `[n]`            | Move the cursor `n` characters left or right. Negative value for left, positive value for right. |
 | `--in-operating` | Move the cursor only if it's currently waiting for an operation.                                 |
 
+<DefaultWithProp id="input.keymap" prop="run" value="move" remove="delete"/>
+
 ### `backward` {#input.backward}
 
 Move back to the start of the current or previous word.
+
+<DefaultWithProp id="input.keymap" prop="run" regex="^backward"/>
 
 ### `forward` {#input.forward}
 
@@ -743,6 +877,8 @@ Move forward to the start of the next word.
 | --------------- | ---------------------------------------------------- |
 | `--end-of-word` | Move forward to the end of the current or next word. |
 
+<DefaultWithProp id="input.keymap" prop="run" regex="^forward"/>
+
 ### `insert` {#input.insert}
 
 Enter insert mode. This action is only available in normal mode.
@@ -751,9 +887,13 @@ Enter insert mode. This action is only available in normal mode.
 | --------------- | ------------------------ |
 | `--append`      | Insert after the cursor. |
 
+<DefaultWithProp id="input.keymap" prop="run" value="insert" remove="delete"/>
+
 ### `visual` {#input.visual}
 
 Enter visual mode. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="visual"/>
 
 ### `delete` {#input.delete}
 
@@ -764,9 +904,13 @@ Delete the selected characters. This action is only available in normal mode.
 | `--cut`         | Cut the selected characters into clipboard, instead of only deleting them. |
 | `--insert`      | Delete and enter insert mode.                                              |
 
+<DefaultWithProp id="input.keymap" prop="run" value="delete"/>
+
 ### `yank` {#input.yank}
 
 Copy the selected characters. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="yank"/>
 
 ### `paste` {#input.paste}
 
@@ -776,17 +920,25 @@ Paste the copied characters after the cursor. This action is only available in n
 | --------------- | ---------------------------------------------- |
 | `--before`      | Paste the copied characters before the cursor. |
 
+<DefaultWithProp id="input.keymap" prop="run" value="paste"/>
+
 ### `undo` {#input.undo}
 
 Undo the last operation. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="undo"/>
 
 ### `redo` {#input.redo}
 
 Redo the last operation. This action is only available in normal mode.
 
+<DefaultWithProp id="input.keymap" prop="run" value="redo"/>
+
 ### `help` {#input.help}
 
 Open the help menu. This action is only available in normal mode.
+
+<DefaultWithProp id="input.keymap" prop="run" value="help"/>
 
 ### `backspace` {#input.backspace}
 
@@ -795,6 +947,8 @@ Delete the character before the cursor. This action is only available in insert 
 | Argument/Option | Description                            |
 | --------------- | -------------------------------------- |
 | `--under`       | Delete the character under the cursor. |
+
+<DefaultWithProp id="input.keymap" prop="run" value="backspace"/>
 
 ### `kill` {#input.kill}
 
@@ -807,13 +961,19 @@ Kill the specified range of characters. This action is only available in insert 
 | `"backward"`    | Kill backwards to the start of the current word. |
 | `"forward"`     | Kill forwards to the end of the current word.    |
 
+<DefaultWithProp id="input.keymap" prop="run" value="kill"/>
+
 ### `plugin` {#input.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin). This action is only available in normal mode.
 
+<DefaultWithProp id="input.keymap" prop="run" value="plugin"/>
+
 ### `noop` {#input.noop}
 
 See [`noop` action](#mgr.noop).
+
+<DefaultWithProp id="input.keymap" prop="run" value="noop"/>
 
 ## [confirm] {#confirm}
 
@@ -825,13 +985,19 @@ Cancel and close the confirmation dialog.
 | --------------- | ------------------------ |
 | `--submit`      | Submit the confirmation. |
 
+<DefaultWithProp id="confirm.keymap" prop="run" value="close"/>
+
 ### `arrow` {#confirm.arrow}
 
 <KeymapArrow />
 
+<DefaultWithProp id="confirm.keymap" prop="run" value="arrow"/>
+
 ### `help` {#confirm.help}
 
 Open the help menu.
+
+<DefaultWithProp id="confirm.keymap" prop="run" value="help"/>
 
 ## [cmp] {#cmp}
 
@@ -843,17 +1009,25 @@ Hide the completion menu.
 | --------------- | ---------------------- |
 | `--submit`      | Submit the completion. |
 
+<DefaultWithProp id="cmp.keymap" prop="run" value="close"/>
+
 ### `arrow` {#cmp.arrow}
 
 <KeymapArrow />
+
+<DefaultWithProp id="cmp.keymap" prop="run" value="arrow"/>
 
 ### `help` {#cmp.help}
 
 Open the help menu.
 
+<DefaultWithProp id="cmp.keymap" prop="run" value="help"/>
+
 ### `plugin` {#cmp.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
+
+<DefaultWithProp id="cmp.keymap" prop="run" value=""/>
 
 ### `noop` {#cmp.noop}
 
@@ -865,22 +1039,35 @@ See [`noop` action](#mgr.noop).
 
 Hide the help menu.
 
+<DefaultWithProp id="help.keymap" prop="run" value="close"/>
+
 ### `escape` {#help.escape}
 
 Clear the filter, or hide the help menu.
+
+<DefaultWithProp id="help.keymap" prop="run" value="escape"/>
 
 ### `arrow` {#help.arrow}
 
 <KeymapArrow />
 
+<DefaultWithProp id="help.keymap" prop="run" value="rrow"/>
+
 ### `filter` {#help.filter}
 
 Apply a filter for the help items.
+
+<DefaultWithProp id="help.keymap" prop="run" value="filter"/>
 
 ### `plugin` {#help.plugin}
 
 See [Functional plugin](/docs/plugins/overview#functional-plugin).
 
+<DefaultWithProp id="help.keymap" prop="run" value="plugin"/>
+
 ### `noop` {#help.noop}
 
 See [`noop` action](#mgr.noop).
+
+<DefaultWithProp id="help.keymap" prop="run" value="noop"/>
+

--- a/versioned_docs/version-26.5.6/configuration/theme.md
+++ b/versioned_docs/version-26.5.6/configuration/theme.md
@@ -4,6 +4,7 @@ description: Learn how to configure your Yazi theme.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import {DefaultTheme} from '@site/src/components/Default'
 
 # theme.toml
 
@@ -87,6 +88,8 @@ overall = { bg = "#1e1e2e" }
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="app.overall"/>
+
 ## [mgr] {#mgr}
 
 ### `cwd` {#mgr.cwd}
@@ -97,6 +100,8 @@ CWD text style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.cwd"/>
+
 ### `find_keyword` {#mgr.find_keyword}
 
 Style of the highlighted portion in the filename.
@@ -104,6 +109,8 @@ Style of the highlighted portion in the filename.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.find_keyword"/>
 
 ### `find_position` {#mgr.find_position}
 
@@ -113,6 +120,8 @@ Style of current file location in all found files to the right of the filename.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.find_position" />
+
 ### `symlink_target` {#mgr.symlink_target}
 
 Style for the path that a symbolic link points to, e.g., the ` -> /path/to/target` part in `my_symbolic_file -> /path/to/target`.
@@ -120,6 +129,8 @@ Style for the path that a symbolic link points to, e.g., the ` -> /path/to/targe
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.symlink_target" />
 
 ### `marker_copied` {#mgr.marker_copied}
 
@@ -129,6 +140,8 @@ Copied file marker style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.marker_copied" />
+
 ### `marker_cut` {#mgr.marker_cut}
 
 Cut file marker style.
@@ -136,6 +149,8 @@ Cut file marker style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.marker_cut" />
 
 ### `marker_marked` {#mgr.marker_marked}
 
@@ -145,6 +160,8 @@ Marker style of pre-selected file in visual mode.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.marker_marked" />
+
 ### `marker_selected` {#mgr.marker_selected}
 
 Selected file marker style.
@@ -152,6 +169,8 @@ Selected file marker style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.marker_selected" />
 
 ### `count_copied` {#mgr.count_copied}
 
@@ -161,6 +180,8 @@ Style of copied file number.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.count_copied" />
+
 ### `count_cut` {#mgr.count_cut}
 
 Style of cut file number.
@@ -168,6 +189,8 @@ Style of cut file number.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.count_cut" />
 
 ### `count_selected` {#mgr.count_selected}
 
@@ -177,6 +200,8 @@ Style of selected file number.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mgr.count_selected" />
+
 ### `border_symbol` {#mgr.border_symbol}
 
 Border symbol, e.g. `"│"`.
@@ -185,6 +210,8 @@ Border symbol, e.g. `"│"`.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="mgr.border_symbol" />
+
 ### `border_style` {#mgr.border_style}
 
 Border style.
@@ -192,6 +219,8 @@ Border style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mgr.border_style" />
 
 ### `syntect_theme` {#mgr.syntect_theme}
 
@@ -203,6 +232,9 @@ For example, `"~/Downloads/Dracula.tmTheme"`, not available after using a flavor
 | ---- | -------- |
 | Type | `string` |
 
+
+<DefaultTheme id="mgr.syntect_theme" />
+
 ## [indicator]
 
 ### `parent` {#indicator.parent}
@@ -213,6 +245,8 @@ Indicator bar style, in the parent pane.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="indicator.parent" />
+
 ### `current` {#indicator.current}
 
 Indicator bar style, in the current pane.
@@ -220,6 +254,8 @@ Indicator bar style, in the current pane.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="indicator.current" />
 
 ### `preview` {#indicator.preview}
 
@@ -229,6 +265,8 @@ Indicator bar style, in the preview pane.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="indicator.preview" />
+
 ### `padding` {#indicator.padding}
 
 Padding around indicator bar, e.g. `{ open = "▐", close = "▌" }`, which makes a square indicator.
@@ -236,6 +274,8 @@ Padding around indicator bar, e.g. `{ open = "▐", close = "▌" }`, which make
 |      |                                   |
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
+
+<DefaultTheme id="indicator.padding" />
 
 ## [tabs] {#tabs}
 
@@ -252,6 +292,8 @@ Active tab style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="tabs.active" />
+
 ### `inactive` {#tabs.inactive}
 
 Inactive tab style.
@@ -259,6 +301,8 @@ Inactive tab style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="tabs.inactive" />
 
 ### `sep_inner` {#tabs.sep_inner}
 
@@ -268,6 +312,8 @@ Inner separator symbol, e.g. `{ open = "[", close = "]" }`.
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
 
+<DefaultTheme id="tabs.sep_inner" />
+
 ### `sep_outer` {#tabs.sep_outer}
 
 Outer separator symbol, e.g. `{ open = "", close = "" }`.
@@ -275,6 +321,8 @@ Outer separator symbol, e.g. `{ open = "", close = "" }`.
 |      |                                   |
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
+
+<DefaultTheme id="tabs.sep_outer" />
 
 ## [mode] {#mode}
 
@@ -286,6 +334,8 @@ Normal mode main style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mode.normal_main" />
+
 ### `normal_alt` {#mode.normal_alt}
 
 Normal mode alternative style.
@@ -293,6 +343,8 @@ Normal mode alternative style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mode.normal_alt" />
 
 ### `select_main` {#mode.select_main}
 
@@ -302,6 +354,8 @@ Select mode main style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mode.select_main" />
+
 ### `select_alt` {#mode.select_alt}
 
 Select mode alternative style.
@@ -309,6 +363,8 @@ Select mode alternative style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mode.select_alt" />
 
 ### `unset_main` {#mode.unset_main}
 
@@ -318,6 +374,8 @@ Unset mode main style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="mode.unset_main" />
+
 ### `unset_alt` {#mode.unset_alt}
 
 Unset mode alternative style.
@@ -325,6 +383,8 @@ Unset mode alternative style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="mode.unset_alt" />
 
 ## [status] {#status}
 
@@ -341,6 +401,8 @@ Overall status bar style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.overall" />
+
 ### `sep_left` {#status.sep_left}
 
 Left separator symbol, e.g. `{ open = "", close = "]" }`.
@@ -348,6 +410,8 @@ Left separator symbol, e.g. `{ open = "", close = "]" }`.
 |      |                                   |
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
+
+<DefaultTheme id="status.sep_left" />
 
 ### `sep_right` {#status.sep_right}
 
@@ -357,6 +421,8 @@ Right separator symbol, e.g. `{ open = "[", close = "" }`.
 | ---- | --------------------------------- |
 | Type | `{ open: string, close: string }` |
 
+<DefaultTheme id="status.sep_right" />
+
 ### `perm_type` {#status.perm_type}
 
 Style of the file type symbol, such as `d` for directory, `-` for file, `l` for symlink, etc.
@@ -364,6 +430,8 @@ Style of the file type symbol, such as `d` for directory, `-` for file, `l` for 
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.perm_type" />
 
 ### `perm_read` {#status.perm_read}
 
@@ -373,6 +441,8 @@ Style of the read permission symbol (`r`).
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.perm_read" />
+
 ### `perm_write` {#status.perm_write}
 
 Style of the write permission symbol (`w`).
@@ -380,6 +450,8 @@ Style of the write permission symbol (`w`).
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.perm_write" />
 
 ### `perm_exec` {#status.perm_exec}
 
@@ -389,6 +461,8 @@ Style of the execute permission symbol (`x`).
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.perm_exec" />
+
 ### `perm_sep` {#status.perm_sep}
 
 Style of the permission separator symbol (`-`).
@@ -396,6 +470,8 @@ Style of the permission separator symbol (`-`).
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.perm_sep" />
 
 ### `progress_label` {#status.progress_label}
 
@@ -405,6 +481,8 @@ Progress label style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.progress_label" />
+
 ### `progress_normal` {#status.progress_normal}
 
 Style of the progress bar when it is not in an error state.
@@ -413,6 +491,8 @@ Style of the progress bar when it is not in an error state.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="status.progress_normal" />
+
 ### `progress_error` {#status.progress_error}
 
 Style of the progress bar when an error occurs.
@@ -420,6 +500,8 @@ Style of the progress bar when an error occurs.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="status.progress_error" />
 
 ## [which] {#which}
 
@@ -431,6 +513,8 @@ Number of columns.
 | ---- | ----------------- |
 | Type | `1` \| `2` \| `3` |
 
+<DefaultTheme id="which.cols" />
+
 ### `mask` {#which.mask}
 
 Mask style.
@@ -438,6 +522,8 @@ Mask style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="which.mask" />
 
 ### `cand` {#which.cand}
 
@@ -447,6 +533,8 @@ Candidate key style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="which.cand" />
+
 ### `rest` {#which.rest}
 
 Rest key style.
@@ -454,6 +542,8 @@ Rest key style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="which.rest" />
 
 ### `desc` {#which.desc}
 
@@ -463,6 +553,8 @@ Description style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="which.desc" />
+
 ### `separator` {#which.separator}
 
 Separator symbol, e.g. `" -> "`.
@@ -471,6 +563,8 @@ Separator symbol, e.g. `" -> "`.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="which.separator" />
+
 ### `separator_style` {#which.separator_style}
 
 Separator style.
@@ -478,6 +572,8 @@ Separator style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="which.separator_style" />
 
 ## [confirm] {#confirm}
 
@@ -489,6 +585,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="confirm.border" />
+
 ### `title` {#confirm.title}
 
 Title style.
@@ -496,6 +594,8 @@ Title style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="confirm.title" />
 
 ### `body` {#confirm.body}
 
@@ -505,6 +605,8 @@ Body style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="confirm.body" />
+
 ### `list` {#confirm.list}
 
 List style, which is the style of the list of items below the content.
@@ -512,6 +614,8 @@ List style, which is the style of the list of items below the content.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="confirm.list" />
 
 ### `btn_yes` {#confirm.btn_yes}
 
@@ -521,6 +625,8 @@ The style of the yes button.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="confirm.btn_yes" />
+
 ### `btn_no` {#confirm.btn_no}
 
 The style of the no button.
@@ -528,6 +634,8 @@ The style of the no button.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="confirm.btn_no" />
 
 ### `btn_labels` {#confirm.btn_labels}
 
@@ -538,6 +646,8 @@ The first string is the label for the yes button and the second is the label for
 |      |                    |
 | ---- | ------------------ |
 | Type | `[string, string]` |
+
+<DefaultTheme id="confirm.btn_labels" />
 
 ## [spot] {#spot}
 
@@ -554,6 +664,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="spot.border" />
+
 ### `title` {#spot.title}
 
 Title style.
@@ -561,6 +673,8 @@ Title style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="spot.title" />
 
 ### `tbl_col` {#spot.tbl_col}
 
@@ -570,6 +684,8 @@ The style of the selected column in the table.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="spot.tbl_col" />
+
 ### `tbl_cell` {#spot.tbl_cell}
 
 The style of the selected cell in the table.
@@ -577,6 +693,9 @@ The style of the selected cell in the table.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+
+<DefaultTheme id="spot.tbl_cell" />
 
 ## [notify] {#notify}
 
@@ -588,6 +707,8 @@ Style of the info title.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="notify.title_info" />
+
 ### `title_warn` {#notify.title_warn}
 
 Style of the warning title.
@@ -596,6 +717,8 @@ Style of the warning title.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="notify.title_warn" />
+
 ### `title_error` {#notify.title_error}
 
 Style of the error title.
@@ -603,6 +726,8 @@ Style of the error title.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="notify.title_error" />
 
 ## [pick] {#pick}
 
@@ -614,6 +739,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="pick.border" />
+
 ### `active` {#pick.active}
 
 Selected item style.
@@ -622,6 +749,8 @@ Selected item style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="pick.active" />
+
 ### `inactive` {#pick.inactive}
 
 Unselected item style.
@@ -629,6 +758,9 @@ Unselected item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+
+<DefaultTheme id="pick.inactive" />
 
 ## [input] {#input}
 
@@ -640,6 +772,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="input.border" />
+
 ### `title` {#input.title}
 
 Title style.
@@ -647,6 +781,8 @@ Title style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="input.title" />
 
 ### `value` {#input.value}
 
@@ -656,6 +792,8 @@ Value style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="input.value" />
+
 ### `selected` {#input.selected}
 
 Selected value style.
@@ -663,6 +801,8 @@ Selected value style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="input.selected" />
 
 ## [cmp] {#cmp}
 
@@ -674,6 +814,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="cmp.border" />
+
 ### `active` {#cmp.active}
 
 Selected item style.
@@ -681,6 +823,8 @@ Selected item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="cmp.active" />
 
 ### `inactive` {#cmp.inactive}
 
@@ -690,6 +834,8 @@ Unselected item style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="cmp.inactive" />
+
 ### `icon_file` {#cmp.icon_file}
 
 File icon.
@@ -697,6 +843,8 @@ File icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="cmp.icon_file" />
 
 ### `icon_folder` {#cmp.icon_folder}
 
@@ -706,6 +854,8 @@ Folder icon.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="cmp.icon_folder" />
+
 ### `icon_command` {#cmp.icon_command}
 
 Command icon.
@@ -713,6 +863,8 @@ Command icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="cmp.icon_command" />
 
 ## [tasks] {#tasks}
 
@@ -724,6 +876,8 @@ Border style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="tasks.border" />
+
 ### `title` {#tasks.title}
 
 Title style.
@@ -732,6 +886,8 @@ Title style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="tasks.title" />
+
 ### `hovered` {#tasks.hovered}
 
 Hovered item style.
@@ -739,6 +895,8 @@ Hovered item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="tasks.hovered" />
 
 ## [help] {#help}
 
@@ -750,6 +908,8 @@ Key column style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="help.on" />
+
 ### `run` {#help.run}
 
 Action column style.
@@ -757,6 +917,8 @@ Action column style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="help.run" />
 
 ### `desc` {#help.desc}
 
@@ -766,6 +928,8 @@ Description column style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="help.desc" />
+
 ### `hovered` {#help.hovered}
 
 Hovered item style.
@@ -773,6 +937,8 @@ Hovered item style.
 |      |                         |
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
+
+<DefaultTheme id="help.hovered" />
 
 ### `footer` {#help.footer}
 
@@ -782,6 +948,8 @@ Footer style.
 | ---- | ----------------------- |
 | Type | [`Style`](#types.style) |
 
+<DefaultTheme id="help.footer" />
+
 ### `icon_info` {#help.icon_info}
 
 Info icon.
@@ -789,6 +957,8 @@ Info icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="notify.icon_info" />
 
 ### `icon_warn` {#help.icon_warn}
 
@@ -798,6 +968,8 @@ Warning icon.
 | ---- | -------- |
 | Type | `string` |
 
+<DefaultTheme id="notify.icon_warn" />
+
 ### `icon_error` {#help.icon_error}
 
 Error icon.
@@ -805,6 +977,8 @@ Error icon.
 |      |          |
 | ---- | -------- |
 | Type | `string` |
+
+<DefaultTheme id="notify.icon_error" />
 
 ## [filetype] {#filetype}
 
@@ -842,6 +1016,8 @@ You can restrict the specific type of files through `is`, noting that it must be
 - `orphan`: Orphan symbolic link
 - `sock`: Socket
 - `sticky`: File with sticky bit set
+
+<DefaultTheme id="filetype" />
 
 ## [icon] {#icon}
 
@@ -919,3 +1095,5 @@ prepend_conds = [
 	{ if = "!(dir | link)", text = "📄" },  # Normal files (not directories or symlinks)
 ]
 ```
+<DefaultTheme id="icon" raw={true}/>
+

--- a/versioned_docs/version-26.5.6/configuration/yazi.md
+++ b/versioned_docs/version-26.5.6/configuration/yazi.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 description: Learn how to configure Yazi's basic functionality.
 ---
+import Default, {Defaults} from "@site/src/components/Default";
 
 # yazi.toml
 
@@ -19,6 +20,8 @@ Manager layout by ratio, 3-element array. For example:
 
 Set the value to `0` to hide the corresponding panel, but at least one panel must be visible (non-zero).
 
+<Default id="mgr.ratio"/>
+
 ### `sort_by` {#mgr.sort_by}
 
 File sorting method.
@@ -32,12 +35,16 @@ File sorting method.
 - `"size"`: Sort by file size.
 - `"random"`: Sort randomly.
 
+<Default id="mgr.sort_by"/>
+
 ### `sort_sensitive` {#mgr.sort_sensitive}
 
 Sort case-sensitively.
 
 - `true`: Case-sensitive
 - `false`: Case-insensitive
+
+<Default id="mgr.sort_sensitive"/>
 
 ### `sort_reverse` {#mgr.sort_reverse}
 
@@ -46,12 +53,16 @@ Display files in reverse order.
 - `true`: Reverse order
 - `false`: Normal order
 
+<Default id="mgr.sort_reverse"/>
+
 ### `sort_dir_first` {#mgr.sort_dir_first}
 
 Display directories first.
 
 - `true`: Directories first
 - `false`: Normal order
+
+<Default id="mgr.sort_dir_first"/>
 
 ### `sort_translit` {#mgr.sort_translit}
 
@@ -61,6 +72,8 @@ This is useful for files that contain Hungarian characters.
 
 - `true`: Enabled
 - `false`: Disabled
+
+<Default id="mgr.sort_translit"/>
 
 ### `linemode` {#mgr.linemode}
 
@@ -98,12 +111,16 @@ function Linemode:size_and_mtime()
 end
 ```
 
+<Default id="mgr.linemode"/>
+
 ### `show_hidden` {#mgr.show_hidden}
 
 Show hidden files.
 
 - `true`: Show
 - `false`: Do not show
+
+<Default id="mgr.show_hidden"/>
 
 ### `show_symlink` {#mgr.show_symlink}
 
@@ -112,11 +129,15 @@ Show the path that the symlink points to after the filename.
 - `true`: Show
 - `false`: Do not show
 
+<Default id="mgr.show_symlink"/>
+
 ### `scrolloff` {#mgr.scrolloff}
 
 The number of files to keep above and below the cursor when moving through the file list.
 
 If the value is larger than half the screen height (e.g. `200`), the cursor will be centered.
+
+<Default id="mgr.scrolloff"/>
 
 ### `mouse_events` {#mgr.mouse_events}
 
@@ -132,6 +153,8 @@ If the array is empty, disable the mouse.
 
 Usually, you don't need to change it, unless the plugin you're using requires enabling a certain event.
 
+<Default id="mgr.mouse_events"/>
+
 ## [preview] {#preview}
 
 ### `wrap` {#preview.wrap}
@@ -141,9 +164,13 @@ Wrap long lines in the code preview.
 - `"yes"`: Enable word wrap
 - `"no"`: Disable word wrap
 
+<Default id="preview.wrap"/>
+
 ### `tab_size` {#preview.tab_size}
 
 The width of a tab character (`\t`) in spaces.
+
+<Default id="preview.tab_size"/>
 
 ### `max_width` {#preview.max_width}
 
@@ -151,11 +178,15 @@ Maximum preview width for images. Run `yazi --clear-cache` after changing this f
 
 This value is also used for preloading images; the larger it is, the larger the image cache generated, which consumes more CPU.
 
+<Default id="preview.max_width"/>
+
 ### `max_height` {#preview.max_height}
 
 Maximum preview height for images. Run `yazi --clear-cache` after changing this for it to take effect.
 
 This value is also used for preloading images; the larger it is, the larger the image cache generated, which consumes more CPU.
+
+<Default id="preview.max_height"/>
 
 ### `cache_dir` {#preview.cache_dir}
 
@@ -171,6 +202,8 @@ This is to alleviate lag caused by some terminal emulators struggling to render 
 
 See https://github.com/sxyazi/yazi/pull/1512 for more information.
 
+<Default id="preview.image_delay"/>
+
 ### `image_filter` {#preview.image_filter}
 
 The filter used on image downscaling, available values:
@@ -184,11 +217,15 @@ They are arranged in order from fast to slow, and from poor to good quality - La
 
 See the example and benchmark here: https://docs.rs/image/0.24.8/image/imageops/enum.FilterType.html#examples
 
+<Default id="preview.image_filter"/>
+
 ### `image_quality` {#preview.image_quality}
 
 Quality on pre-caching images, range 50-90.
 
 The larger value, the better image quality, but slower with more CPU consumption, and generates larger cache files that occupy more storage space.
+
+<Default id="preview.image_quality"/>
 
 ### `ueberzug_scale` / `ueberzug_offset` {#preview.ueberzug_scale}
 
@@ -198,6 +235,9 @@ The larger value, the better image quality, but slower with more CPU consumption
 This is useful for solving [a bug of Überzug++ image size calculation](https://github.com/jstkdng/ueberzugpp/issues/122).
 
 If your monitor has a `2.0` scale factor, and is running on Wayland under Hyprland, you may need to set `ueberzug_scale: 0.5`, and adjust the value of `ueberzug_offset` according to your case, to offset this issue.
+
+<Default id="preview.ueberzug_scale" show_key="ueberzug_scale"/>
+<Default id="preview.ueberzug_offset" show_key="ueberzug_offset"/>
 
 ## [opener] {#opener}
 
@@ -235,6 +275,9 @@ Available options are as follows:
 - `orphan`: Keep the process running even if Yazi has exited, once specified, the process will be detached from the task scheduling system.
 - `desc`: Description of the opener, display in interactive components, such as "Open with" and help menu.
 - `for`: The opener is only available on this system, similar to [per-OS keybindings](/docs/configuration/keymap#per-os).
+
+
+<Default id="opener" raw={true}/>
 
 ## [open] {#open}
 
@@ -282,39 +325,57 @@ With that:
 - You can [`spot`](/docs/configuration/keymap#mgr.spot) on a file to check it's mime-type with the default <kbd>Tab</kbd> key.
 - If `use` is an array containing multiple openers, all commands in these openers will be merged. [`open`](/docs/configuration/keymap#mgr.open) will run the first of these commands; [`open --interactive`](/docs/configuration/keymap#mgr.open) will list all of these commands in the "open with" menu.
 
+<Default id="open" raw={true} />
+
 ## [tasks] {#tasks}
 
 ### `file_workers` {#tasks.file_workers}
 
 Max concurrent file operations, such as copy, cut, delete, etc.
 
+<Default id="tasks.file_workers"/>
+
 ### `plugin_workers` {#tasks.plugin_workers}
 
 Max concurrent functional-plugin tasks.
+
+<Default id="tasks.plugin_workers"/>
 
 ### `fetch_workers` {#tasks.fetch_workers}
 
 Max concurrent fetch tasks.
 
+<Default id="tasks.fetch_workers"/>
+
 ### `preload_workers` {#tasks.preload_workers}
 
 Max concurrent preload tasks.
+
+<Default id="tasks.preload_workers"/>
 
 ### `process_workers` {#tasks.process_workers}
 
 Max concurrent processes.
 
+<Default id="tasks.process_workers"/>
+
 ### `bizarre_retry` {#tasks.bizarre_retry}
 
 Maximum number of retries when a bizarre failure occurs.
+
+<Default id="tasks.bizarre_retry"/>
 
 ### `suppress_preload` {#tasks.suppress_preload}
 
 Exclude the preload tasks created by the system from the task list, do not report their progress, and do not consider them on app exit confirming.
 
+<Default id="tasks.suppress_preload"/>
+
 ### `image_alloc` {#tasks.image_alloc}
 
 Maximum memory allocation limit in bytes for decoding a single image, `0` for unlimited.
+
+<Default id="tasks.image_alloc"/>
 
 ### `image_bound` {#tasks.image_bound}
 
@@ -338,6 +399,8 @@ Here are the available options for a single rule:
 - `if`: Run the fetcher only if the condition is met.
 - `prio`: Task scheduling priority. One of `high`, `normal` or `low`.
 - `group`: Group of the fetcher. Only the first matching fetcher in the same group will be run.
+
+<Default id="plugin.fetchers" raw={true}/>
 
 ### previewers {#plugin.previewers}
 
@@ -378,6 +441,8 @@ Yazi comes with these previewer plugins:
 
 If you want to create your own previewer, see [Previewer API](/docs/plugins/overview#previewer).
 
+<Default id="plugin.previewers" raw={true} />
+
 ### preloaders {#plugin.preloaders}
 
 You can prepend or append new preview rules to the default `preloaders` under `[plugin]` by `prepend_preloaders` and `append_preloaders`, see [Configuration mixing](/docs/configuration/overview#mixing) for details.
@@ -406,6 +471,8 @@ Yazi comes with these preloader plugins:
 
 If you want to create your own preloader, see [Preloader API](/docs/plugins/overview#preloader).
 
+<Default id="plugin.preloaders" raw={true}/>
+
 ## [input] {#input}
 
 ### `cursor_blink` {#input.cursor_blink}
@@ -420,13 +487,19 @@ You can customize the title and position of each input. The following inputs are
 As for position, it consists of two parts: [Origin](#input.origin) and [Offset](#input.offset).
 The origin is the top-left corner of the input, and the offset is the increment from this origin. Together, they determine the area of the input on the screen.
 
+<Default id="input.cursor_blink"/>
+
 ### Origin {#input.origin}
 
 See [`Origin`](/docs/plugins/aliases#origin) for available values.
 
+<Defaults section="input" searchKey="origin" />
+
 ### Offset {#input.offset}
 
 As for the offset, it's a 4-element tuple: `(x, y, width, height)`.
+
+<Defaults section="input" searchKey="offset" />
 
 ### Placeholder {#input.placeholder}
 
@@ -434,39 +507,50 @@ Some inputs have special placeholders that will be replaced with actual content 
 
 - cd_title: String
 
-  Title of the [`cd --interactive`](/docs/configuration/keymap/#mgr.cd) input used to enter the target path.
+  - Title of the [`cd --interactive`](/docs/configuration/keymap/#mgr.cd) input used to enter the target path.
+  - <Default id="input.cd_title"/>
 
 - create_title: [String, String]
 
-  It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` action.
+  - It's a tuple of 2-element: first for [`create`](/docs/configuration/keymap/#mgr.create) input title, second for `create --dir` action.
+  - <Default id="input.create_title"/>
+
 
 - rename_title: String
 
-  Title of the [`rename`](/docs/configuration/keymap/#mgr.rename) input used to enter the new name.
+  - Title of the [`rename`](/docs/configuration/keymap/#mgr.rename) input used to enter the new name.
+  - <Default id="input.rename_title"/>
 
 - filter_title: String
 
-  Title of the [`filter`](/docs/configuration/keymap/#mgr.filter) input used to enter the keyword.
+  - Title of the [`filter`](/docs/configuration/keymap/#mgr.filter) input used to enter the keyword.
+  - <Default id="input.filter_title"/>
+
 
 - find_title: [String, String]
 
-  It's a tuple of 2-element: first for [`find`](/docs/configuration/keymap/#mgr.find), second for `find --previous`.
+  - It's a tuple of 2-element: first for [`find`](/docs/configuration/keymap/#mgr.find), second for `find --previous`. 
+  - <Default id="input.find_title"/>
 
 - search_title: String
 
   - `{n}`: Name of the current [`search`](/docs/configuration/keymap/#mgr.search) engine.
+  - <Default id="input.search_title"/>
 
 - shell_title: [String, String]
 
-  It's a tuple of 2-element: first for [`shell --interactive`](/docs/configuration/keymap/#mgr.shell), second for `shell --interactive --block`.
+  - It's a tuple of 2-element: first for [`shell --interactive`](/docs/configuration/keymap/#mgr.shell), second for `shell --interactive --block`.
+  - <Default id="input.shell_title"/>
 
 ## [confirm] {#confirm}
 
 Same as the [`[input]`](#input) section. There are a few available: `trash`, `delete`, `overwrite` and `quit`.
+<Default id="confirm" raw={true}/>
 
 ## [pick] {#pick}
 
 Same as the [`[input]`](#input) section. Available selectors: `open`.
+<Default id="pick" raw={true}/>
 
 ## [which] {#which}
 
@@ -478,6 +562,8 @@ Candidate sorting method.
 - `"key"`: Sort by key.
 - `"desc`: Sort by description.
 
+<Default id="which.sort_by"/>
+
 ### `sort_sensitive` {#which.sort_sensitive}
 
 Sort case-sensitively.
@@ -485,12 +571,17 @@ Sort case-sensitively.
 - `true`: Case-sensitive
 - `false`: Case-insensitive
 
+<Default id="which.sort_sensitive"/>
+
 ### `sort_reverse` {#which.sort_reverse}
 
 Display candidates in reverse order.
 
 - `true`: Reverse order
 - `false`: Normal order
+
+<Default id="which.sort_reverse"/>
+
 
 ### `sort_translit` {#which.sort_translit}
 
@@ -500,3 +591,5 @@ This is useful for files that contain Hungarian characters.
 
 - `true`: Enabled
 - `false`: Disabled
+
+<Default id="which.sort_translit"/>


### PR DESCRIPTION
## What?

- Default value components that are applied to theme, yazi & keymap config docs
- Correct defaults are loaded based on page path/route and an id variable that works identically to the anchor links. Simply write down `<Default id="mgr.sort_by"/>` in yazi.md and be done with it.
- Updates default values with only one unattended-able script run (circumventing the problems with #341)
- Handles both light & dark theme defaults, squishing them together if they are identical
- Manually checked every displayed default value: barring human slip-ups, it should all be correct

## Further questions (in scope)
- Implementation:
  - I added "no default configurations" message for the noop action, is it preferred it has no message at all?
  - I forgot about the `shipped` tag and used latest stable docs, as this - if i'm correct - the only version that gets show on the website. I can change it to `shipped` or include `nightly` docs separately too

### Further questions (not necessarily in scope)
- yazi:
    - `tasks.show' is in the wrong spot-ish: it is shown under [tasks], but needs to/is default called from [mgr]
- keymap:
    - `--far` not documented
    - `casefy` not documented
    - `marker_symbol` not documented
    - `icon_{info,warn,error}` are in the [help] section, although the defaults configure them within [notify]. Which is the correct usage?

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi

