### PR TITLE
Add jumplist to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -67,6 +67,7 @@ Jumping:
 - [cd-git-root.yazi](https://github.com/ciarandg/cd-git-root.yazi) - Changes directory to the root of the git repository you are currently in.
 - [fazif.yazi](https://github.com/Shallow-Seek/fazif.yazi) - Search over selected item with `fd`, `rg` `rga` and spawn any FZF configurations in Yazi.
 - [yafg.yazi](https://github.com/XYenon/yafg.yazi) - Fuzzy find and grep in Yazi with ripgrep and fzf, opening selected matches in your editor at the matched line.
+- [jumplist.yazi](https://github.com/0xHouss/jumplist.yazi) - Navigate back and forward through the directories you have visited, like Vim's jumplist.
 
 Bookmarks:
 

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -67,6 +67,7 @@ Jumping:
 - [cd-git-root.yazi](https://github.com/ciarandg/cd-git-root.yazi) - Changes directory to the root of the git repository you are currently in.
 - [fazif.yazi](https://github.com/Shallow-Seek/fazif.yazi) - Search over selected item with `fd`, `rg` `rga` and spawn any FZF configurations in Yazi.
 - [yafg.yazi](https://github.com/XYenon/yafg.yazi) - Fuzzy find and grep in Yazi with ripgrep and fzf, opening selected matches in your editor at the matched line.
+- [jumplist.yazi](https://github.com/0xHouss/jumplist.yazi) - Navigate back and forward through the directories you have visited, like Vim's jumplist.
 
 Bookmarks:
 


### PR DESCRIPTION
Adds [jumplist.yazi](https://github.com/0xHouss/jumplist.yazi) under Functional plugins → Jumping.

It records the directories you visit and lets you move back and forward through them with Vim-style `<C-o>` / `<C-i>` bindings. Directories that no longer exist are skipped when jumping.

Checked against the requirements in "Add yours":

- **Functional** — tested against Yazi 26.5.6.
- **Follow conventions** — the repository is named `jumplist.yazi` and contains `main.lua`, `README.md` and `LICENSE`.
- **i18n** — the README is in English.

Added to both `docs/resources.md` and `versioned_docs/version-26.5.6/resources.md`.