### PR TITLE
[Amend] Add functional plugin 'goto-sibling' to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -68,6 +68,7 @@ Jumping:
 - [fazif.yazi](https://github.com/Shallow-Seek/fazif.yazi) - Search over selected item with `fd`, `rg` `rga` and spawn any FZF configurations in Yazi.
 - [yafg.yazi](https://github.com/XYenon/yafg.yazi) - Fuzzy find and grep in Yazi with ripgrep and fzf, opening selected matches in your editor at the matched line.
 - [jumplist.yazi](https://github.com/0xHouss/jumplist.yazi) - Navigate back and forward through the directories you have visited, like Vim's jumplist.
+- [goto-sibling.yazi](https://github.com/FichteFoll/goto-sibling.yazi) - Directly navigate to the next or previous sibling folder.
 
 Bookmarks:
 


### PR DESCRIPTION
Just adding a reference to https://github.com/FichteFoll/goto-sibling.yazi which I created a couple months ago.

---

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
