### PR TITLE
Add quarto.yazi to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -105,6 +105,7 @@ File actions:
 - [kdeconnect-send.yazi](https://github.com/Deepak22903/kdeconnect-send.yazi) - Send selected files to your smartphone or other devices using KDE Connect.
 - [zoom.yazi](https://github.com/yazi-rs/plugins/tree/main/zoom.yazi) - Zoom in or out of the preview image.
 - [pandoc.yazi](https://github.com/lmnek/pandoc.yazi) - Convert markup files to different formats via Pandoc.
+- [quarto-render.yazi](https://github.com/songwupei/yazi-quarto) - One-key render `.typ`/`.md`/`.qmd` files to PDF, DOCX, HTML, PNG, and slides (PPTX + Beamer) via Typst and Quarto, with auto-detected GB/T 9704 government doc formatting.
 
 Clipboard:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -105,7 +105,7 @@ File actions:
 - [kdeconnect-send.yazi](https://github.com/Deepak22903/kdeconnect-send.yazi) - Send selected files to your smartphone or other devices using KDE Connect.
 - [zoom.yazi](https://github.com/yazi-rs/plugins/tree/main/zoom.yazi) - Zoom in or out of the preview image.
 - [pandoc.yazi](https://github.com/lmnek/pandoc.yazi) - Convert markup files to different formats via Pandoc.
-- [quarto-render.yazi](https://github.com/songwupei/yazi-quarto) - One-key render `.typ`/`.md`/`.qmd` files to PDF, DOCX, HTML, PNG, and slides (PPTX + Beamer) via Typst and Quarto, with auto-detected GB/T 9704 government doc formatting.
+- [quarto.yazi](https://github.com/songwupei/quarto.yazi) - One-key render `.typ`/`.md`/`.qmd` files to PDF, DOCX, HTML, PNG, and slides (PPTX + Beamer) via Typst and Quarto, with auto-detected GB/T 9704 government doc formatting.
 
 Clipboard:
 

--- a/versioned_docs/version-26.8.15/resources.md
+++ b/versioned_docs/version-26.8.15/resources.md
@@ -105,6 +105,7 @@ File actions:
 - [kdeconnect-send.yazi](https://github.com/Deepak22903/kdeconnect-send.yazi) - Send selected files to your smartphone or other devices using KDE Connect.
 - [zoom.yazi](https://github.com/yazi-rs/plugins/tree/main/zoom.yazi) - Zoom in or out of the preview image.
 - [pandoc.yazi](https://github.com/lmnek/pandoc.yazi) - Convert markup files to different formats via Pandoc.
+- [quarto-render.yazi](https://github.com/songwupei/yazi-quarto) - One-key render `.typ`/`.md`/`.qmd` files to PDF, DOCX, HTML, PNG, and slides (PPTX + Beamer) via Typst and Quarto, with auto-detected GB/T 9704 government doc formatting.
 
 Clipboard:
 

--- a/versioned_docs/version-26.8.15/resources.md
+++ b/versioned_docs/version-26.8.15/resources.md
@@ -105,7 +105,7 @@ File actions:
 - [kdeconnect-send.yazi](https://github.com/Deepak22903/kdeconnect-send.yazi) - Send selected files to your smartphone or other devices using KDE Connect.
 - [zoom.yazi](https://github.com/yazi-rs/plugins/tree/main/zoom.yazi) - Zoom in or out of the preview image.
 - [pandoc.yazi](https://github.com/lmnek/pandoc.yazi) - Convert markup files to different formats via Pandoc.
-- [quarto-render.yazi](https://github.com/songwupei/yazi-quarto) - One-key render `.typ`/`.md`/`.qmd` files to PDF, DOCX, HTML, PNG, and slides (PPTX + Beamer) via Typst and Quarto, with auto-detected GB/T 9704 government doc formatting.
+- [quarto.yazi](https://github.com/songwupei/quarto.yazi) - One-key render `.typ`/`.md`/`.qmd` files to PDF, DOCX, HTML, PNG, and slides (PPTX + Beamer) via Typst and Quarto, with auto-detected GB/T 9704 government doc formatting.
 
 Clipboard:
 


### PR DESCRIPTION
Add quarto.yazi plugin — one-key render `.typ`/`.md`/`.qmd` files to PDF, DOCX, HTML, PNG, and slides (PPTX + Beamer) via Typst + Quarto, with GB/T 9704 government doc formatting support.

## Checklist

- [x] **Amend**: changes applied to both the newest released version (`versioned_docs/version-26.8.15/`) and synced to nightly (`docs/`).

- [x] **Amend**: change applies to the newest stable version of Yazi.