### PR TITLE
Added sduf plugin

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -163,6 +163,7 @@ UI enhancements:
 - [linemode-plus.yazi](https://github.com/barbanevosa/linemode-plus.yazi) - Advanced linemode customization with configurable date format and combined size+mtime view.
 - [vscode-git-colors.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-colors.yazi) - Color file names by their git status, VS Code style, with status letters for files and dot badges for directories in every column.
 - [mobile-auto-layout.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/mobile-auto-layout.yazi) - Adapt column widths to content and screen size, with a reading mode that widens the preview, built for phone-narrow terminals.
+- [sduf.yazi](https://github.com/shafayetejaman/sduf.yazi) - A storage (disk) space meter for the status bar, showing used/total space.
 
 Diagnostics:
 

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -162,6 +162,7 @@ UI enhancements:
 - [linemode-plus.yazi](https://github.com/barbanevosa/linemode-plus.yazi) - Advanced linemode customization with configurable date format and combined size+mtime view.
 - [vscode-git-colors.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-colors.yazi) - Color file names by their git status, VS Code style, with status letters for files and dot badges for directories in every column.
 - [mobile-auto-layout.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/mobile-auto-layout.yazi) - Adapt column widths to content and screen size, with a reading mode that widens the preview, built for phone-narrow terminals.
+- [sduf.yazi](https://github.com/shafayetejaman/sduf.yazi) - A storage (disk) space meter for the status bar, showing used/total space.
 
 Diagnostics:
 


### PR DESCRIPTION
Plugin that adds a storage (disk) space meter to the status bar, showing used/total space.
Mostly Vive coded

Thank you for helping improve the documentation - much appreciated!
Checklist
The documentation consists of:
- The newest release (located in the /versioned_docs/version-*/ directory)
- The nightly (located in the /docs/ directory)
These two versions require separate handling for changes:
- New: changes to the nightly documentation that is not published
- Amend: changes to the stable documentation that is published
Please make sure to check and complete:
- I have chosen the right change type (at least one of the following meets)
- New: my change only applies to the nightly documentation
- Amend: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- I used the right contents (at least one of the following meets)
- New: my change applies to the nightly version of Yazi
- Amend: my change applies to the newest stable version of Yazi
Changes
- Added sduf.yazi (https://github.com/shafayetejaman/sduf.yazi) to the "Functional plugins → UI enhancements" section of resources.md
- Synced the entry in both docs/resources.md (nightly) and versioned_docs/version-26.5.6/resources.md (newest release)