### PR TITLE
fix(features): don't autoplay all feature videos at once

### DIFF
--- a/src/components/Highlights/index.tsx
+++ b/src/components/Highlights/index.tsx
@@ -16,7 +16,7 @@ function Card(props: CardProps) {
 	return (
 		<li key={props.title} className="card shadow--md">
 			<div className={clsx("card__image")}>
-				<video src={props.video} width="100%" autoPlay controls loop muted></video>
+        <video src={`${props.video}#t=0.001`} width="100%" controls preload="metadata"></video>
 			</div>
 			<div className="card__body">
 				<Heading as="h4">{props.title}</Heading>


### PR DESCRIPTION
## Problem

The [features page](https://yazi-rs.github.io/features/) embeds 7 videos that all use `autoplay` + `loop`. On desktop, all 7 are visible and decode/play simultaneously, which causes severe lag — on my machine the page becomes nearly unusable, and it's likely to put off new users landing there. On mobile they aren't all shown at once, so the problem is desktop-specific.

## Change

In `src/components/Highlights/index.tsx`, remove `autoPlay` / `loop` / `muted` from the `<video>` element and switch to `preload="metadata"`. A `#t=0.001` media fragment is appended to the source so each card shows the video's first frame as a thumbnail instead of an empty box. Videos now play only on user interaction via the existing `controls`.

This keeps a visual preview on every card while ensuring only one video decodes at a time (when the user starts it), removing the lag.

Tested locally in Firefox and LibreWolf on NixOS.

## Checklist

> Note: This change is to a React component (`src/components/Highlights/index.tsx`), not to versioned documentation content, so the nightly/stable distinction below doesn't strictly apply. Marking **New** as it applies to the current site.

- [x] I have chosen the right change type
  - **New**: my change only applies to the nightly documentation
- [x] I used the right contents
  - **New**: my change applies to the nightly version of Yazi

Related to sxyazi/yazi#4213