### PR TITLE
Fix two shellcheck issues

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,7 +28,7 @@ function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
-	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd"
+	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd" || builtin true
 	command rm -f -- "$tmp"
 }
 ```
@@ -72,7 +72,7 @@ y() {
 	shift $(($# - 1))
 	set -- "$(command cat < "$1"; printf .; command rm -f -- "$1")"
 	set -- "${1%.}"
-	[ "$1" != "$PWD" ] && [ -d "$1" ] && command cd -- "$1"
+	[ "$1" != "$PWD" ] && [ -d "$1" ] && command cd -- "$1" || command true
 }
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,7 +25,8 @@ We suggest using this `y` shell wrapper that provides the ability to change the 
 
 ```bash
 function y() {
-	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
+	local tmp cwd
+	tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
 	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd" || builtin true

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,8 +25,7 @@ We suggest using this `y` shell wrapper that provides the ability to change the 
 
 ```bash
 function y() {
-	local tmp cwd
-	tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+	local tmp cwd; tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
 	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd" || builtin true

--- a/versioned_docs/version-26.5.6/quick-start.md
+++ b/versioned_docs/version-26.5.6/quick-start.md
@@ -28,7 +28,7 @@ function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
-	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd"
+	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd" || builtin true
 	command rm -f -- "$tmp"
 }
 ```
@@ -72,7 +72,7 @@ y() {
 	shift $(($# - 1))
 	set -- "$(command cat < "$1"; printf .; command rm -f -- "$1")"
 	set -- "${1%.}"
-	[ "$1" != "$PWD" ] && [ -d "$1" ] && command cd -- "$1"
+	[ "$1" != "$PWD" ] && [ -d "$1" ] && command cd -- "$1" || command true
 }
 ```
 

--- a/versioned_docs/version-26.5.6/quick-start.md
+++ b/versioned_docs/version-26.5.6/quick-start.md
@@ -25,7 +25,8 @@ We suggest using this `y` shell wrapper that provides the ability to change the 
 
 ```bash
 function y() {
-	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
+	local tmp cwd
+	tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
 	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd" || builtin true

--- a/versioned_docs/version-26.5.6/quick-start.md
+++ b/versioned_docs/version-26.5.6/quick-start.md
@@ -25,8 +25,7 @@ We suggest using this `y` shell wrapper that provides the ability to change the 
 
 ```bash
 function y() {
-	local tmp cwd
-	tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+	local tmp cwd; tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
 	command yazi "$@" --cwd-file="$tmp"
 	IFS= read -r -d '' cwd < "$tmp"
 	[ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd" || builtin true


### PR DESCRIPTION
Refer to https://www.shellcheck.net/wiki/SC2164
Refer to https://www.shellcheck.net/wiki/SC2155

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
