### PR TITLE
Add indium.yazi to Previewers → Archives

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -28,6 +28,7 @@ Archives:
 - [ouch.yazi](https://github.com/ndtoan96/ouch.yazi) - An [ouch](https://github.com/ouch-org/ouch) plugin for Yazi, supporting preview and compression.
 - [zless-preview.yazi](https://github.com/vmikk/zless-preview.yazi) - Preview compressed text files using `zless`.
 - [comicthumb.yazi](https://github.com/navysky12/comicthumb.yazi) - Preview for comicbook archive files using p7zip on Linux.
+- [indium.yazi](https://github.com/sudo-megas/indium.yazi) - Preview archives in yazi with INDIUM — mode, size, packed size, method, encryption and timestamps, calling no external archiver.
 
 Binaries:
 

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -28,6 +28,7 @@ Archives:
 - [ouch.yazi](https://github.com/ndtoan96/ouch.yazi) - An [ouch](https://github.com/ouch-org/ouch) plugin for Yazi, supporting preview and compression.
 - [zless-preview.yazi](https://github.com/vmikk/zless-preview.yazi) - Preview compressed text files using `zless`.
 - [comicthumb.yazi](https://github.com/navysky12/comicthumb.yazi) - Preview for comicbook archive files using p7zip on Linux.
+- [indium.yazi](https://github.com/sudo-megas/indium.yazi) - Preview archives in yazi with INDIUM — mode, size, packed size, method, encryption and timestamps, calling no external archiver.
 
 Binaries:
 


### PR DESCRIPTION
Adds indium.yazi, an archive previewer backed by INDIUM.

It links its decompressors in and shells out to nothing, so archives preview on machines with no 7-Zip installed, where the built-in previewer cannot list anything at all. Shows mode, size, packed size, method, encryption and timestamps.

- Repository: https://github.com/sudo-megas/indium.yazi
- Linux-only, and noted as such in the README and in the entry
- main.lua / README.md / LICENSE at the root, README in English
- Same line added to docs/ and versioned_docs/version-26.5.6/, whose Archives sections are identical