### PR TITLE
docs: add lsblk-mount.yazi to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -154,6 +154,7 @@ UI enhancements:
 - [toggle-pane.yazi](https://github.com/yazi-rs/plugins/tree/main/toggle-pane.yazi) - Toggle the show, hide, and maximize states for different panes: parent, current, and preview.
 - [git.yazi](https://github.com/yazi-rs/plugins/tree/main/git.yazi) - Show the status of Git file changes as linemode in the file list.
 - [mount.yazi](https://github.com/yazi-rs/plugins/tree/main/mount.yazi) - A mount manager for Yazi, providing disk mount, unmount, and eject functionality.
+- [lsblk-mount.yazi](https://github.com/PHONE1X/lsblk-mount.yazi) - A fork of mount.yazi using lsblk's JSON device tree for more reliable discovery, plus a mountpoint column and error notifications.
 - [starship.yazi](https://github.com/Rolv-Apneseth/starship.yazi) - Starship prompt plugin for Yazi.
 - [omp.yazi](https://github.com/saumyajyoti/omp.yazi) - oh-my-posh prompt plugin for Yazi.
 - [yatline.yazi](https://github.com/imsi32/yatline.yazi) - Customize header-line and status-line with an easy configuration.


### PR DESCRIPTION
Adds lsblk-mount.yazi under Functional plugins — a fork of mount.yazi using lsblk's JSON device tree for more reliable discovery.