### PR TITLE
docs: add xdg-user-dirs plugin

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -164,6 +164,7 @@ UI enhancements:
 - [vscode-git-colors.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-colors.yazi) - Color file names by their git status, VS Code style, with status letters for files and dot badges for directories in every column.
 - [mobile-auto-layout.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/mobile-auto-layout.yazi) - Adapt column widths to content and screen size, with a reading mode that widens the preview, built for phone-narrow terminals.
 - [sduf.yazi](https://github.com/shafayetejaman/sduf.yazi) - A storage (disk) space meter for the status bar, showing used/total space.
+- [xdg-user-dirs.yazi](https://github.com/jaja360/xdg-user-dirs.yazi) - Display dedicated icons for configured XDG user directories via `xdg-user-dir`.
 
 Diagnostics:
 

--- a/versioned_docs/version-26.5.6/resources.md
+++ b/versioned_docs/version-26.5.6/resources.md
@@ -163,6 +163,7 @@ UI enhancements:
 - [vscode-git-colors.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-colors.yazi) - Color file names by their git status, VS Code style, with status letters for files and dot badges for directories in every column.
 - [mobile-auto-layout.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/mobile-auto-layout.yazi) - Adapt column widths to content and screen size, with a reading mode that widens the preview, built for phone-narrow terminals.
 - [sduf.yazi](https://github.com/shafayetejaman/sduf.yazi) - A storage (disk) space meter for the status bar, showing used/total space.
+- [xdg-user-dirs.yazi](https://github.com/jaja360/xdg-user-dirs.yazi) - Display dedicated icons for configured XDG user directories via `xdg-user-dir`.
 
 Diagnostics:
 


### PR DESCRIPTION
This PR adds [xdg-user-dirs.yazi](https://github.com/jaja360/xdg-user-dirs.yazi) to the Resources page.

The plugin displays special icons for configured XDG user directories, including localized names such as French `Téléchargements`.

---

Thank you for helping improve the documentation - much appreciated!

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi
