### PR TITLE
Adding Tasks view shortcut to quick start docs.

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -328,13 +328,13 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 | <kbd>}</kbd>                                  | Swap current tab with next tab     |
 | <kbd>Ctrl</kbd> + <kbd>c</kbd>                | Close the current tab              |
 
-### Tasks View
+### Task manager
 
-Background tasks such as file operations can be views in the Tasks view.
+View running background tasks or failed tasks in the task manager.
 
 | Key binding                                   | Action                             |
 | --------------------------------------------- | ---------------------------------- |
-| <kbd>w</kbd>                                  | Open the Tasks view                |
+| <kbd>w</kbd>                                  | Open the task manager              |
 
 ## Flavors
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -328,6 +328,14 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 | <kbd>}</kbd>                                  | Swap current tab with next tab     |
 | <kbd>Ctrl</kbd> + <kbd>c</kbd>                | Close the current tab              |
 
+### Tasks View
+
+Background tasks such as file operations can be views in the Tasks view.
+
+| Key binding                                   | Action                             |
+| --------------------------------------------- | ---------------------------------- |
+| <kbd>w</kbd>                                  | Open the Tasks view                |
+
 ## Flavors
 
 Pick a color scheme you like from our [flavors repository](https://github.com/yazi-rs/flavors), or [cook a flavor](/docs/flavors/overview#cooking)!

--- a/versioned_docs/version-26.8.15/quick-start.md
+++ b/versioned_docs/version-26.8.15/quick-start.md
@@ -328,13 +328,13 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 | <kbd>}</kbd>                                  | Swap current tab with next tab     |
 | <kbd>Ctrl</kbd> + <kbd>c</kbd>                | Close the current tab              |
 
-### Tasks View
+### Task manager
 
-Background tasks such as file operations can be views in the Tasks view.
+View running background tasks or failed tasks in the task manager.
 
 | Key binding                                   | Action                             |
 | --------------------------------------------- | ---------------------------------- |
-| <kbd>w</kbd>                                  | Open the Tasks view                |
+| <kbd>w</kbd>                                  | Open the task manager              |
 
 ## Flavors
 

--- a/versioned_docs/version-26.8.15/quick-start.md
+++ b/versioned_docs/version-26.8.15/quick-start.md
@@ -328,6 +328,14 @@ _Observation: <kbd>,</kbd> ⇒ <kbd>a</kbd> indicates pressing the <kbd>,</kbd> 
 | <kbd>}</kbd>                                  | Swap current tab with next tab     |
 | <kbd>Ctrl</kbd> + <kbd>c</kbd>                | Close the current tab              |
 
+### Tasks View
+
+Background tasks such as file operations can be views in the Tasks view.
+
+| Key binding                                   | Action                             |
+| --------------------------------------------- | ---------------------------------- |
+| <kbd>w</kbd>                                  | Open the Tasks view                |
+
 ## Flavors
 
 Pick a color scheme you like from our [flavors repository](https://github.com/yazi-rs/flavors), or [cook a flavor](/docs/flavors/overview#cooking)!


### PR DESCRIPTION
It was unclear to me how to open the Tasks view, and it ultimately required looking at the keymap defaults toml. It is better exposed in the docs. I added a section at the bottom but happy to move it somewhere else. 

This is my first PR for yazi, hope I'm doing this right.

## Checklist

The documentation consists of:

- The newest release (located in the `/versioned_docs/version-*/` directory)
- The nightly (located in the `/docs/` directory)

These two versions require separate handling for changes:

- **New**: changes to the nightly documentation that is not published
- **Amend**: changes to the stable documentation that is published

Please make sure to check and complete:

- [x] I have chosen the right change type (at least one of the following meets)
  - ~~**New**: my change only applies to the nightly documentation~~
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - ~~**New**: my change applies to the nightly version of Yazi~~
  - **Amend**: my change applies to the newest stable version of Yazi
