### PR TITLE
Add search-leave.yazi plugin to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -67,6 +67,7 @@ Jumping:
 - [yafg.yazi](https://github.com/XYenon/yafg.yazi) - Fuzzy find and grep in Yazi with ripgrep and fzf, opening selected matches in your editor at the matched line.
 - [jumplist.yazi](https://github.com/0xHouss/jumplist.yazi) - Navigate back and forward through the directories you have visited, like Vim's jumplist.
 - [goto-sibling.yazi](https://github.com/FichteFoll/goto-sibling.yazi) - Directly navigate to the next or previous sibling folder.
+- [search-leave.yazi](https://github.com/ownself/search-leave.yazi) - Leave search results while keeping the selected file hovered in its actual directory.
 
 Bookmarks:
 

--- a/versioned_docs/version-26.8.15/resources.md
+++ b/versioned_docs/version-26.8.15/resources.md
@@ -70,6 +70,7 @@ Jumping:
 - [yafg.yazi](https://github.com/XYenon/yafg.yazi) - Fuzzy find and grep in Yazi with ripgrep and fzf, opening selected matches in your editor at the matched line.
 - [jumplist.yazi](https://github.com/0xHouss/jumplist.yazi) - Navigate back and forward through the directories you have visited, like Vim's jumplist.
 - [goto-sibling.yazi](https://github.com/FichteFoll/goto-sibling.yazi) - Directly navigate to the next or previous sibling folder.
+- [search-leave.yazi](https://github.com/ownself/search-leave.yazi) - Leave search results while keeping the selected file hovered in its actual directory..
 
 Bookmarks:
 

--- a/versioned_docs/version-26.8.15/resources.md
+++ b/versioned_docs/version-26.8.15/resources.md
@@ -66,7 +66,7 @@ Jumping:
 - [yafg.yazi](https://github.com/XYenon/yafg.yazi) - Fuzzy find and grep in Yazi with ripgrep and fzf, opening selected matches in your editor at the matched line.
 - [jumplist.yazi](https://github.com/0xHouss/jumplist.yazi) - Navigate back and forward through the directories you have visited, like Vim's jumplist.
 - [goto-sibling.yazi](https://github.com/FichteFoll/goto-sibling.yazi) - Directly navigate to the next or previous sibling folder.
-- [search-leave.yazi](https://github.com/ownself/search-leave.yazi) - Leave search results while keeping the selected file hovered in its actual directory..
+- [search-leave.yazi](https://github.com/ownself/search-leave.yazi) - Leave search results while keeping the selected file hovered in its actual directory.
 
 Bookmarks:
 


### PR DESCRIPTION
search-leave.yazi is a small plugin that improves the experience of leaving an fd or rg search results page. When invoked from a search page, it returns to the actual parent directory of the currently hovered result and keeps that file hovered, so users do not lose their position or need to locate the file again. Outside search pages, it simply falls back to Yazi’s built-in leave command. It is intended to be mapped to h as a drop-in replacement for the default leave behavior.

This is an Amend change. The plugin requires Yazi v26.8.15 or later. The documentation change has been applied to both the latest stable documentation and the nightly documentation.

## Checklist

- [x] I have chosen the right change type (at least one of the following meets)
  - **New**: my change only applies to the nightly documentation
  - **Amend**: my change targets the newest released documentation, and these changes have also been synced to the nightly documentation
- [x] I used the right contents (at least one of the following meets)
  - **New**: my change applies to the nightly version of Yazi
  - **Amend**: my change applies to the newest stable version of Yazi