### PR TITLE
docs(resources): add dog.yazi previewer

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -48,6 +48,7 @@ Jupyter notebooks:
 
 Misc:
 
+- [dog.yazi](https://github.com/edden27/dog.yazi) - Use `dog` for text/code yazi previews with syntax highlighting powered by tree-sitter. Faster than bat, with better theming.
 - [mdv-previewer.yazi](https://github.com/WhoSowSee/mdv-previewer.yazi) - A preview plugin for Text and Markdown files that uses [mdv](https://github.com/WhoSowSee/mdv) to render content
 - [rich-preview.yazi](https://github.com/AnirudhG07/rich-preview.yazi) - Preview Markdown, JSON, CSV, etc. using [rich-cli](https://github.com/textualize/rich-cli)
 - [vscode-git-gutter.yazi](https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-gutter.yazi) - Preview text and code with syntax highlighting, line numbers, and a VS Code style git change gutter.


### PR DESCRIPTION
Added a previewer plugin that uses my cli `dog` for previewer - syntax highlighting for 17 lang via tree-sitter (and plain text for others), like bat but faster (~5ms startup too) and better theming. Tested on Mac on latest yazi release. Requires dog cli (shows link to install if not found). Supports Mac & Linux. All noted in readme.

Plugin: https://github.com/edden27/dog.yazi
dog: https://github.com/edden27/dog
Docs: https://sh.dog